### PR TITLE
Fix CI: use Java 21 and suppress Node.js 20 deprecation warning

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - name: Checkout code
@@ -31,7 +33,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       - name: Build APK
         run: |


### PR DESCRIPTION
## Summary

- **Java 17 → 21**: `capacitor.build.gradle` sets `sourceCompatibility`/`targetCompatibility` to `VERSION_21`, causing Gradle to crash when only Java 17 was available. Bumped `java-version` in the workflow to match.
- **Node.js 20 deprecation**: Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` at the job level to opt runner actions into Node 24 now, ahead of GitHub's forced migration in June 2026.

## Test plan

- [ ] Merge PR and confirm the Actions build on `main` passes end-to-end (npm ci → tsc/vite build → Gradle assembleRelease → APK artifact upload)
- [ ] Confirm no Node.js 20 deprecation warning in the build log

https://claude.ai/code/session_015VfxRKYHnNeuA3Ci79DT4v

---
_Generated by [Claude Code](https://claude.ai/code/session_015VfxRKYHnNeuA3Ci79DT4v)_