### PR TITLE
Add Capacitor sync step to CI workflow

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Build web app
         run: npm run build
 
+      - name: Sync Capacitor
+        run: npx cap sync android
+
       - name: Setup Java
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
## Summary

- Adds `npx cap sync android` between the web build and the Gradle build steps
- `cap sync` copies `dist/` into the Android assets folder and generates `capacitor-cordova-android-plugins/` (including `cordova.variables.gradle`)
- Without this step Gradle fails at configure time: `Could not read script '...cordova.variables.gradle' as it does not exist`

## Test plan

- [ ] Merge and confirm the full CI pipeline passes: npm ci → build → cap sync → Gradle assembleRelease → APK artifact upload

https://claude.ai/code/session_015VfxRKYHnNeuA3Ci79DT4v

---
_Generated by [Claude Code](https://claude.ai/code/session_015VfxRKYHnNeuA3Ci79DT4v)_