### PR TITLE
Switch to assembleDebug so the APK can be sideloaded

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -41,11 +41,11 @@ jobs:
       - name: Build APK
         run: |
           cd android
-          ./gradlew assembleRelease
+          ./gradlew assembleDebug
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
           name: jamba-apk
-          path: android/app/build/outputs/apk/release/
+          path: android/app/build/outputs/apk/debug/
           retention-days: 30


### PR DESCRIPTION
## Summary

- Switches `assembleRelease` → `assembleDebug` and updates the artifact path to match
- Release builds without a signing keystore produce an unsigned APK that Android rejects at install time with "you can't install this on your device"
- Debug builds are auto-signed with the debug keystore and can be sideloaded directly

## Test plan

- [ ] Merge, let CI run, download the `jamba-apk` artifact, install on device

https://claude.ai/code/session_015VfxRKYHnNeuA3Ci79DT4v

---
_Generated by [Claude Code](https://claude.ai/code/session_015VfxRKYHnNeuA3Ci79DT4v)_