### PR TITLE
Add model favorites, expand uncensored list, and AI character builder

### DIFF
--- a/src/api/openrouter.ts
+++ b/src/api/openrouter.ts
@@ -23,6 +23,42 @@ export async function fetchModels(apiKey: string): Promise<Model[]> {
   return (data.data as Model[]) ?? []
 }
 
+export interface CompleteChatOptions {
+  apiKey: string
+  modelId: string
+  messages: Pick<Message, 'role' | 'content'>[]
+  systemPrompt?: string
+  signal?: AbortSignal
+  temperature?: number
+}
+
+export async function completeChat(opts: CompleteChatOptions): Promise<string> {
+  const { apiKey, modelId, messages, systemPrompt, signal, temperature } = opts
+  const res = await fetch(`${BASE_URL}/chat/completions`, {
+    method: 'POST',
+    headers: headers(apiKey),
+    signal,
+    body: JSON.stringify({
+      model: modelId,
+      stream: false,
+      ...(temperature !== undefined ? { temperature } : {}),
+      messages: systemPrompt
+        ? [{ role: 'system', content: systemPrompt }, ...messages]
+        : [...messages],
+    }),
+  })
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`HTTP ${res.status}: ${text}`)
+  }
+  const data = await res.json()
+  const content = data?.choices?.[0]?.message?.content
+  if (typeof content !== 'string') {
+    throw new Error('No content returned from model.')
+  }
+  return content
+}
+
 export type StreamChatOptions = {
   apiKey: string
   modelId: string

--- a/src/components/characters/AICharacterBuilder.tsx
+++ b/src/components/characters/AICharacterBuilder.tsx
@@ -1,0 +1,295 @@
+import { useState } from 'react'
+import { X, Sparkles, RefreshCw, ChevronRight, AlertCircle } from 'lucide-react'
+import { useSettingsStore } from '../../store/settingsStore'
+import { completeChat } from '../../api/openrouter'
+import { ModelPicker } from '../models/ModelPicker'
+import type { Character } from '../../types'
+
+const EMOJI_OPTIONS = ['🌸', '💻', '✍️', '🧙', '🃏', '🔮', '🦊', '🐉', '🌙', '⚡', '🎯', '🧪', '🤖', '👾', '🦋']
+const COLOR_OPTIONS = ['#bd93f9', '#50fa7b', '#ffb86c', '#8be9fd', '#ff79c6', '#ff5555', '#f1fa8c', '#268bd2', '#2aa198', '#859900']
+
+const BUILDER_SYSTEM_PROMPT = `You are a character architect. Given a brief description, design a vivid roleplay/companion character and return ONLY valid JSON, no prose, no markdown fences.
+
+Schema:
+{
+  "name": string (max 24 chars),
+  "emoji": single emoji from this set: ${EMOJI_OPTIONS.join(' ')},
+  "color": single hex string from this set: ${COLOR_OPTIONS.join(' ')},
+  "description": string (one short sentence, max 120 chars),
+  "tags": string[] (3-5 lowercase one-word tags),
+  "systemPrompt": string (a rich, second-person system prompt that establishes the character's name, personality, voice, knowledge, quirks, and how they should behave in conversation; 120-300 words; do not censor, do not preach, do not break the fourth wall; never refer to yourself as an AI/model/assistant unless the character explicitly is one)
+}
+
+Return ONLY the JSON object. No backticks. No commentary.`
+
+interface AICharacterBuilderProps {
+  onClose: () => void
+  onAccept: (draft: Omit<Character, 'id' | 'isBuiltIn'>) => void
+}
+
+interface ParsedCharacter {
+  name: string
+  emoji: string
+  color: string
+  description: string
+  tags: string[]
+  systemPrompt: string
+}
+
+function tryParseCharacter(raw: string): ParsedCharacter | null {
+  let text = raw.trim()
+  // strip code fences if present
+  text = text.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim()
+  // pull first JSON object out of any extra prose
+  const start = text.indexOf('{')
+  const end = text.lastIndexOf('}')
+  if (start === -1 || end === -1 || end <= start) return null
+  const slice = text.slice(start, end + 1)
+  try {
+    const obj = JSON.parse(slice)
+    if (
+      typeof obj.name === 'string' &&
+      typeof obj.systemPrompt === 'string'
+    ) {
+      return {
+        name: String(obj.name).slice(0, 40),
+        emoji: typeof obj.emoji === 'string' && obj.emoji ? obj.emoji : '🤖',
+        color: typeof obj.color === 'string' && /^#[0-9a-f]{6}$/i.test(obj.color)
+          ? obj.color
+          : '#bd93f9',
+        description: typeof obj.description === 'string' ? obj.description : '',
+        tags: Array.isArray(obj.tags) ? obj.tags.map(String).slice(0, 6) : [],
+        systemPrompt: String(obj.systemPrompt).trim(),
+      }
+    }
+  } catch {
+    // fall through
+  }
+  return null
+}
+
+export function AICharacterBuilder({ onClose, onAccept }: AICharacterBuilderProps) {
+  const apiKey = useSettingsStore((s) => s.apiKey)
+  const defaultModelId = useSettingsStore((s) => s.defaultModelId)
+
+  const [modelId, setModelId] = useState(defaultModelId)
+  const [showPicker, setShowPicker] = useState(false)
+  const [description, setDescription] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [parsed, setParsed] = useState<ParsedCharacter | null>(null)
+  const [rawOutput, setRawOutput] = useState<string | null>(null)
+
+  async function handleGenerate() {
+    if (!apiKey) { setError('No OpenRouter API key. Add one in Settings first.'); return }
+    if (!description.trim()) { setError('Describe the character first, sugar.'); return }
+    setIsLoading(true)
+    setError(null)
+    setParsed(null)
+    setRawOutput(null)
+    try {
+      const text = await completeChat({
+        apiKey,
+        modelId,
+        systemPrompt: BUILDER_SYSTEM_PROMPT,
+        temperature: 0.9,
+        messages: [
+          {
+            role: 'user',
+            content: `Design a character based on this brief:\n\n${description.trim()}\n\nReturn ONLY the JSON object.`,
+          },
+        ],
+      })
+      setRawOutput(text)
+      const result = tryParseCharacter(text)
+      if (!result) {
+        setError("Model didn't return clean JSON. You can try again or pick a smarter model.")
+      } else {
+        setParsed(result)
+      }
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  function handleUseDraft() {
+    if (!parsed) return
+    onAccept({
+      name: parsed.name,
+      emoji: parsed.emoji,
+      color: parsed.color,
+      description: parsed.description,
+      tags: parsed.tags,
+      systemPrompt: parsed.systemPrompt,
+    })
+  }
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center p-4"
+        style={{ background: 'rgba(0,0,0,0.7)' }}
+        onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+      >
+        <div
+          className="w-full max-w-xl max-h-[90vh] rounded-2xl flex flex-col shadow-2xl fade-in"
+          style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border)' }}
+        >
+          <div className="flex items-center justify-between px-4 py-3 border-b border-subtle shrink-0">
+            <h2 className="font-bold text-base flex items-center gap-2">
+              <Sparkles size={16} style={{ color: 'var(--accent)' }} />
+              AI Character Builder
+            </h2>
+            <button onClick={onClose} className="btn-ghost p-1.5 rounded-lg">
+              <X size={16} />
+            </button>
+          </div>
+
+          <div className="flex-1 overflow-y-auto p-4 flex flex-col gap-4 min-h-0">
+            {/* Model picker row */}
+            <div>
+              <label className="text-xs text-muted mb-1.5 block">Builder model</label>
+              <button
+                onClick={() => setShowPicker(true)}
+                className="w-full flex items-center justify-between gap-2 input-field text-sm py-2 hover:border-accent transition-colors"
+              >
+                <span className="truncate font-mono text-xs">{modelId}</span>
+                <ChevronRight size={14} className="shrink-0 text-muted" />
+              </button>
+              <p className="text-xs text-muted mt-1.5">
+                Pick any OpenRouter model. Pricier reasoners build richer characters; uncensored models won't water down your fantasy.
+              </p>
+            </div>
+
+            {/* Description */}
+            <div>
+              <label className="text-xs text-muted mb-1.5 block">Character brief</label>
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                rows={5}
+                placeholder="e.g. A jaded ex-spy turned bartender in 1985 East Berlin, drinks vodka neat, speaks in clipped sentences, knows every back-alley contact in Mitte…"
+                className="input-field text-sm resize-none leading-relaxed w-full"
+                disabled={isLoading}
+              />
+            </div>
+
+            <button
+              onClick={handleGenerate}
+              disabled={isLoading || !description.trim()}
+              className="btn-primary text-sm flex items-center justify-center gap-2 disabled:opacity-50"
+            >
+              {isLoading ? (
+                <>
+                  <RefreshCw size={14} className="animate-spin" />
+                  Cooking up a character…
+                </>
+              ) : (
+                <>
+                  <Sparkles size={14} />
+                  Generate
+                </>
+              )}
+            </button>
+
+            {error && (
+              <div
+                className="flex items-start gap-2 text-xs p-3 rounded-lg"
+                style={{
+                  background: 'color-mix(in srgb, var(--danger) 15%, transparent)',
+                  color: 'var(--danger)',
+                }}
+              >
+                <AlertCircle size={14} className="shrink-0 mt-0.5" />
+                <span>{error}</span>
+              </div>
+            )}
+
+            {parsed && (
+              <div
+                className="rounded-xl border p-3 flex flex-col gap-3"
+                style={{ borderColor: 'var(--accent)', background: 'var(--bg-tertiary)' }}
+              >
+                <div className="flex items-center gap-3">
+                  <span
+                    className="text-2xl w-10 h-10 rounded-full flex items-center justify-center shrink-0"
+                    style={{ background: `${parsed.color}22` }}
+                  >
+                    {parsed.emoji}
+                  </span>
+                  <div className="min-w-0">
+                    <div className="font-semibold text-sm" style={{ color: parsed.color }}>
+                      {parsed.name}
+                    </div>
+                    {parsed.description && (
+                      <div className="text-xs text-muted line-clamp-2">{parsed.description}</div>
+                    )}
+                  </div>
+                </div>
+
+                {parsed.tags.length > 0 && (
+                  <div className="flex flex-wrap gap-1">
+                    {parsed.tags.map((t) => (
+                      <span
+                        key={t}
+                        className="text-[10px] px-2 py-0.5 rounded-full"
+                        style={{ background: 'var(--bg-secondary)', color: 'var(--text-secondary)' }}
+                      >
+                        {t}
+                      </span>
+                    ))}
+                  </div>
+                )}
+
+                <div>
+                  <div className="text-xs text-muted mb-1">System prompt</div>
+                  <p
+                    className="text-xs leading-relaxed max-h-40 overflow-y-auto p-2 rounded-md font-mono"
+                    style={{ background: 'var(--bg-secondary)' }}
+                  >
+                    {parsed.systemPrompt}
+                  </p>
+                </div>
+
+                <div className="flex gap-2">
+                  <button onClick={handleUseDraft} className="btn-primary text-xs flex-1">
+                    Use as Draft
+                  </button>
+                  <button
+                    onClick={handleGenerate}
+                    className="btn-ghost text-xs flex-1 border border-subtle"
+                  >
+                    Reroll
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {!parsed && rawOutput && (
+              <details className="text-xs text-muted">
+                <summary className="cursor-pointer">Show raw model output</summary>
+                <pre
+                  className="mt-2 p-2 rounded-md font-mono text-[11px] whitespace-pre-wrap break-words max-h-48 overflow-y-auto"
+                  style={{ background: 'var(--bg-tertiary)' }}
+                >
+                  {rawOutput}
+                </pre>
+              </details>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {showPicker && (
+        <ModelPicker
+          onClose={() => setShowPicker(false)}
+          title="Pick Builder Model"
+          currentModelIdOverride={modelId}
+          onSelectModel={(id) => setModelId(id)}
+        />
+      )}
+    </>
+  )
+}

--- a/src/components/characters/AICharacterBuilder.tsx
+++ b/src/components/characters/AICharacterBuilder.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { X, Sparkles, RefreshCw, ChevronRight, AlertCircle } from 'lucide-react'
+import { X, Sparkles, RefreshCw, ChevronRight, AlertCircle, KeyRound } from 'lucide-react'
 import { useSettingsStore } from '../../store/settingsStore'
 import { completeChat } from '../../api/openrouter'
 import { ModelPicker } from '../models/ModelPicker'
@@ -8,9 +8,7 @@ import type { Character } from '../../types'
 const EMOJI_OPTIONS = ['🌸', '💻', '✍️', '🧙', '🃏', '🔮', '🦊', '🐉', '🌙', '⚡', '🎯', '🧪', '🤖', '👾', '🦋']
 const COLOR_OPTIONS = ['#bd93f9', '#50fa7b', '#ffb86c', '#8be9fd', '#ff79c6', '#ff5555', '#f1fa8c', '#268bd2', '#2aa198', '#859900']
 
-const BUILDER_SYSTEM_PROMPT = `You are a character architect. Given a brief description, design a vivid roleplay/companion character and return ONLY valid JSON, no prose, no markdown fences.
-
-Schema:
+const SCHEMA_BLOCK = `Schema:
 {
   "name": string (max 24 chars),
   "emoji": single emoji from this set: ${EMOJI_OPTIONS.join(' ')},
@@ -22,9 +20,32 @@ Schema:
 
 Return ONLY the JSON object. No backticks. No commentary.`
 
+const CREATE_SYSTEM_PROMPT = `You are a character architect. Given a brief description, design a vivid roleplay/companion character and return ONLY valid JSON, no prose, no markdown fences.
+
+${SCHEMA_BLOCK}`
+
+const REWRITE_SYSTEM_PROMPT = `You are a character editor. You will be given an existing character as JSON plus a note describing how to revise them. Return ONLY a single revised JSON object using the schema below.
+
+Rules:
+- PRESERVE the character's core identity. Keep the existing "name" unless the note explicitly asks to rename. Keep "emoji" and "color" unless the note specifies new ones.
+- REWRITE/EXPAND "description", "tags", and "systemPrompt" per the note. Improve voice, specificity, sensory detail, and characterization.
+- Do not water down. Do not preach. Do not break the fourth wall. Do not refer to the character as an AI/model/assistant unless they explicitly are one.
+
+${SCHEMA_BLOCK}`
+
+interface CreateMode {
+  kind: 'create'
+}
+interface RewriteMode {
+  kind: 'rewrite'
+  existing: Character
+}
+type BuilderMode = CreateMode | RewriteMode
+
 interface AICharacterBuilderProps {
   onClose: () => void
   onAccept: (draft: Omit<Character, 'id' | 'isBuiltIn'>) => void
+  mode?: BuilderMode
 }
 
 interface ParsedCharacter {
@@ -38,9 +59,7 @@ interface ParsedCharacter {
 
 function tryParseCharacter(raw: string): ParsedCharacter | null {
   let text = raw.trim()
-  // strip code fences if present
   text = text.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim()
-  // pull first JSON object out of any extra prose
   const start = text.indexOf('{')
   const end = text.lastIndexOf('}')
   if (start === -1 || end === -1 || end <= start) return null
@@ -68,8 +87,15 @@ function tryParseCharacter(raw: string): ParsedCharacter | null {
   return null
 }
 
-export function AICharacterBuilder({ onClose, onAccept }: AICharacterBuilderProps) {
-  const apiKey = useSettingsStore((s) => s.apiKey)
+export function AICharacterBuilder({ onClose, onAccept, mode }: AICharacterBuilderProps) {
+  const builderMode: BuilderMode = mode ?? { kind: 'create' }
+  const isRewrite = builderMode.kind === 'rewrite'
+
+  const mainKey = useSettingsStore((s) => s.apiKey)
+  const builderKey = useSettingsStore((s) => s.builderApiKey)
+  const effectiveKey = builderKey.trim() || mainKey
+  const usingBuilderKey = builderKey.trim().length > 0
+
   const defaultModelId = useSettingsStore((s) => s.defaultModelId)
 
   const [modelId, setModelId] = useState(defaultModelId)
@@ -81,29 +107,48 @@ export function AICharacterBuilder({ onClose, onAccept }: AICharacterBuilderProp
   const [rawOutput, setRawOutput] = useState<string | null>(null)
 
   async function handleGenerate() {
-    if (!apiKey) { setError('No OpenRouter API key. Add one in Settings first.'); return }
-    if (!description.trim()) { setError('Describe the character first, sugar.'); return }
+    if (!effectiveKey) {
+      setError('No API key set. Add a main or builder key in Settings first.')
+      return
+    }
+    if (!description.trim()) {
+      setError(isRewrite
+        ? 'Tell me what you want changed, sugar.'
+        : 'Describe the character first, sugar.')
+      return
+    }
     setIsLoading(true)
     setError(null)
     setParsed(null)
     setRawOutput(null)
     try {
+      const systemPrompt = isRewrite ? REWRITE_SYSTEM_PROMPT : CREATE_SYSTEM_PROMPT
+      const userContent = isRewrite
+        ? `Existing character JSON:\n${JSON.stringify(
+            {
+              name: builderMode.existing.name,
+              emoji: builderMode.existing.emoji,
+              color: builderMode.existing.color,
+              description: builderMode.existing.description,
+              tags: builderMode.existing.tags,
+              systemPrompt: builderMode.existing.systemPrompt,
+            },
+            null,
+            2,
+          )}\n\nRevision note:\n${description.trim()}\n\nReturn ONLY the revised JSON object.`
+        : `Design a character based on this brief:\n\n${description.trim()}\n\nReturn ONLY the JSON object.`
+
       const text = await completeChat({
-        apiKey,
+        apiKey: effectiveKey,
         modelId,
-        systemPrompt: BUILDER_SYSTEM_PROMPT,
+        systemPrompt,
         temperature: 0.9,
-        messages: [
-          {
-            role: 'user',
-            content: `Design a character based on this brief:\n\n${description.trim()}\n\nReturn ONLY the JSON object.`,
-          },
-        ],
+        messages: [{ role: 'user', content: userContent }],
       })
       setRawOutput(text)
       const result = tryParseCharacter(text)
       if (!result) {
-        setError("Model didn't return clean JSON. You can try again or pick a smarter model.")
+        setError("Model didn't return clean JSON. Try again or pick a smarter model.")
       } else {
         setParsed(result)
       }
@@ -126,6 +171,14 @@ export function AICharacterBuilder({ onClose, onAccept }: AICharacterBuilderProp
     })
   }
 
+  const headerText = isRewrite ? 'AI Punch Up' : 'AI Character Builder'
+  const briefLabel = isRewrite ? 'How should I rewrite them?' : 'Character brief'
+  const briefPlaceholder = isRewrite
+    ? 'e.g. Make her more menacing. Add 1980s East Berlin sensory detail. Tighten the prose, drop the cliches…'
+    : 'e.g. A jaded ex-spy turned bartender in 1985 East Berlin, drinks vodka neat, speaks in clipped sentences, knows every back-alley contact in Mitte…'
+  const generateLabel = isRewrite ? 'Punch It Up' : 'Generate'
+  const acceptLabel = isRewrite ? 'Apply Rewrite' : 'Use as Draft'
+
   return (
     <>
       <div
@@ -140,7 +193,18 @@ export function AICharacterBuilder({ onClose, onAccept }: AICharacterBuilderProp
           <div className="flex items-center justify-between px-4 py-3 border-b border-subtle shrink-0">
             <h2 className="font-bold text-base flex items-center gap-2">
               <Sparkles size={16} style={{ color: 'var(--accent)' }} />
-              AI Character Builder
+              {headerText}
+              {isRewrite && (
+                <span
+                  className="ml-1 text-xs font-normal flex items-center gap-1"
+                  style={{ color: 'var(--text-secondary)' }}
+                >
+                  <span className="text-base">{builderMode.existing.emoji}</span>
+                  <span style={{ color: builderMode.existing.color }}>
+                    {builderMode.existing.name}
+                  </span>
+                </span>
+              )}
             </h2>
             <button onClick={onClose} className="btn-ghost p-1.5 rounded-lg">
               <X size={16} />
@@ -158,19 +222,36 @@ export function AICharacterBuilder({ onClose, onAccept }: AICharacterBuilderProp
                 <span className="truncate font-mono text-xs">{modelId}</span>
                 <ChevronRight size={14} className="shrink-0 text-muted" />
               </button>
-              <p className="text-xs text-muted mt-1.5">
-                Pick any OpenRouter model. Pricier reasoners build richer characters; uncensored models won't water down your fantasy.
-              </p>
+              <div className="flex items-center justify-between gap-2 mt-1.5">
+                <p className="text-xs text-muted">
+                  {isRewrite
+                    ? 'Pick the model doing the rewrite. Smarter / uncensored picks give richer revisions.'
+                    : 'Pick any OpenRouter model. Pricier reasoners build richer characters; uncensored models won’t water down your fantasy.'}
+                </p>
+                {usingBuilderKey && (
+                  <span
+                    className="shrink-0 text-[10px] px-2 py-0.5 rounded-full flex items-center gap-1 font-medium"
+                    style={{
+                      background: 'color-mix(in srgb, var(--accent) 18%, transparent)',
+                      color: 'var(--accent)',
+                    }}
+                    title="Calls go through your builder API key"
+                  >
+                    <KeyRound size={10} />
+                    Builder key
+                  </span>
+                )}
+              </div>
             </div>
 
-            {/* Description */}
+            {/* Brief */}
             <div>
-              <label className="text-xs text-muted mb-1.5 block">Character brief</label>
+              <label className="text-xs text-muted mb-1.5 block">{briefLabel}</label>
               <textarea
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 rows={5}
-                placeholder="e.g. A jaded ex-spy turned bartender in 1985 East Berlin, drinks vodka neat, speaks in clipped sentences, knows every back-alley contact in Mitte…"
+                placeholder={briefPlaceholder}
                 className="input-field text-sm resize-none leading-relaxed w-full"
                 disabled={isLoading}
               />
@@ -184,12 +265,12 @@ export function AICharacterBuilder({ onClose, onAccept }: AICharacterBuilderProp
               {isLoading ? (
                 <>
                   <RefreshCw size={14} className="animate-spin" />
-                  Cooking up a character…
+                  {isRewrite ? 'Reworking…' : 'Cooking up a character…'}
                 </>
               ) : (
                 <>
                   <Sparkles size={14} />
-                  Generate
+                  {generateLabel}
                 </>
               )}
             </button>
@@ -255,7 +336,7 @@ export function AICharacterBuilder({ onClose, onAccept }: AICharacterBuilderProp
 
                 <div className="flex gap-2">
                   <button onClick={handleUseDraft} className="btn-primary text-xs flex-1">
-                    Use as Draft
+                    {acceptLabel}
                   </button>
                   <button
                     onClick={handleGenerate}

--- a/src/components/characters/CharacterSelector.tsx
+++ b/src/components/characters/CharacterSelector.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react'
-import { X, Plus, Edit2, Trash2, Check } from 'lucide-react'
+import { X, Plus, Edit2, Trash2, Check, Sparkles } from 'lucide-react'
 import { useChatStore } from '../../store/chatStore'
 import clsx from 'clsx'
 import type { Character } from '../../types'
+import { AICharacterBuilder } from './AICharacterBuilder'
 
 interface CharacterSelectorProps {
   onClose: () => void
@@ -25,6 +26,7 @@ function CharacterForm({
   const [color, setColor] = useState(initial?.color ?? '#bd93f9')
   const [description, setDescription] = useState(initial?.description ?? '')
   const [systemPrompt, setSystemPrompt] = useState(initial?.systemPrompt ?? '')
+  const tags = initial?.tags ?? []
 
   function handleSave() {
     if (!name.trim() || !systemPrompt.trim()) return
@@ -34,7 +36,7 @@ function CharacterForm({
       color,
       description: description.trim(),
       systemPrompt: systemPrompt.trim(),
-      tags: [],
+      tags,
     })
   }
 
@@ -117,6 +119,8 @@ export function CharacterSelector({ onClose }: CharacterSelectorProps) {
 
   const [editId, setEditId] = useState<string | null>(null)
   const [isCreating, setIsCreating] = useState(false)
+  const [aiDraft, setAiDraft] = useState<Partial<Character> | null>(null)
+  const [showAIBuilder, setShowAIBuilder] = useState(false)
 
   function selectCharacter(charId: string | null) {
     if (!activeChatId) { onClose(); return }
@@ -149,10 +153,21 @@ export function CharacterSelector({ onClose }: CharacterSelectorProps) {
         <div className="flex-1 overflow-y-auto p-4 min-h-0">
           {isCreating ? (
             <div className="mb-4">
-              <h3 className="font-semibold text-sm mb-3">New Character</h3>
+              <h3 className="font-semibold text-sm mb-3 flex items-center gap-2">
+                {aiDraft && <Sparkles size={14} style={{ color: 'var(--accent)' }} />}
+                {aiDraft ? 'New Character (AI Draft)' : 'New Character'}
+              </h3>
               <CharacterForm
-                onSave={(c) => { addCharacter(c); setIsCreating(false) }}
-                onCancel={() => setIsCreating(false)}
+                initial={aiDraft ?? undefined}
+                onSave={(c) => {
+                  addCharacter(c)
+                  setIsCreating(false)
+                  setAiDraft(null)
+                }}
+                onCancel={() => {
+                  setIsCreating(false)
+                  setAiDraft(null)
+                }}
               />
             </div>
           ) : null}
@@ -263,17 +278,37 @@ export function CharacterSelector({ onClose }: CharacterSelectorProps) {
         </div>
 
         {/* Footer */}
-        <div className="border-t border-subtle p-3 shrink-0">
+        <div className="border-t border-subtle p-3 shrink-0 flex gap-2">
           <button
-            onClick={() => setIsCreating(true)}
-            className="btn-ghost flex items-center gap-2 w-full justify-center text-sm border border-subtle rounded-xl py-2"
+            onClick={() => { setAiDraft(null); setIsCreating(true) }}
+            className="btn-ghost flex items-center gap-2 flex-1 justify-center text-sm border border-subtle rounded-xl py-2 disabled:opacity-50"
             disabled={isCreating}
           >
             <Plus size={14} />
-            Create Custom Character
+            Create Custom
+          </button>
+          <button
+            onClick={() => setShowAIBuilder(true)}
+            className="btn-primary flex items-center gap-2 flex-1 justify-center text-sm rounded-xl py-2"
+            title="Use a model to draft a character for you"
+          >
+            <Sparkles size={14} />
+            AI Build
           </button>
         </div>
       </div>
+
+      {showAIBuilder && (
+        <AICharacterBuilder
+          onClose={() => setShowAIBuilder(false)}
+          onAccept={(draft) => {
+            setAiDraft(draft)
+            setIsCreating(true)
+            setEditId(null)
+            setShowAIBuilder(false)
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/characters/CharacterSelector.tsx
+++ b/src/components/characters/CharacterSelector.tsx
@@ -121,6 +121,8 @@ export function CharacterSelector({ onClose }: CharacterSelectorProps) {
   const [isCreating, setIsCreating] = useState(false)
   const [aiDraft, setAiDraft] = useState<Partial<Character> | null>(null)
   const [showAIBuilder, setShowAIBuilder] = useState(false)
+  const [punchUpId, setPunchUpId] = useState<string | null>(null)
+  const punchUpTarget = punchUpId ? characters.find((c) => c.id === punchUpId) ?? null : null
 
   function selectCharacter(charId: string | null) {
     if (!activeChatId) { onClose(); return }
@@ -255,6 +257,14 @@ export function CharacterSelector({ onClose }: CharacterSelectorProps) {
                 {!char.isBuiltIn && (
                   <div className="absolute top-2 right-2 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
                     <button
+                      onClick={(e) => { e.stopPropagation(); setPunchUpId(char.id) }}
+                      className="p-1 rounded-md"
+                      style={{ background: 'var(--bg-secondary)', color: 'var(--accent)' }}
+                      title="AI Punch Up"
+                    >
+                      <Sparkles size={11} />
+                    </button>
+                    <button
                       onClick={(e) => { e.stopPropagation(); setEditId(char.id) }}
                       className="p-1 rounded-md"
                       style={{ background: 'var(--bg-secondary)' }}
@@ -306,6 +316,17 @@ export function CharacterSelector({ onClose }: CharacterSelectorProps) {
             setIsCreating(true)
             setEditId(null)
             setShowAIBuilder(false)
+          }}
+        />
+      )}
+
+      {punchUpTarget && (
+        <AICharacterBuilder
+          mode={{ kind: 'rewrite', existing: punchUpTarget }}
+          onClose={() => setPunchUpId(null)}
+          onAccept={(draft) => {
+            updateCharacter(punchUpTarget.id, draft)
+            setPunchUpId(null)
           }}
         />
       )}

--- a/src/components/models/ModelCard.tsx
+++ b/src/components/models/ModelCard.tsx
@@ -1,6 +1,7 @@
-import { Check } from 'lucide-react'
+import { Check, Star } from 'lucide-react'
 import clsx from 'clsx'
 import { formatContextLength, formatPrice } from '../../utils/modelFilters'
+import { useSettingsStore } from '../../store/settingsStore'
 import type { Model } from '../../types'
 
 interface ModelCardProps {
@@ -13,6 +14,10 @@ export function ModelCard({ model, selected, onSelect }: ModelCardProps) {
   const provider = model.id.split('/')[0] ?? ''
   const modelName = model.id.split('/').slice(1).join('/') || model.id
   const isFree = parseFloat(model.pricing.prompt) === 0
+
+  const favoriteIds = useSettingsStore((s) => s.favoriteModelIds)
+  const toggleFavorite = useSettingsStore((s) => s.toggleFavoriteModel)
+  const isFavorite = favoriteIds.includes(model.id)
 
   return (
     <button
@@ -45,14 +50,29 @@ export function ModelCard({ model, selected, onSelect }: ModelCardProps) {
             <span className="text-xs font-mono text-muted truncate">{modelName}</span>
           </div>
         </div>
-        {selected && (
+        <div className="flex items-center gap-1 shrink-0 mt-0.5">
           <span
-            className="shrink-0 w-5 h-5 rounded-full flex items-center justify-center mt-0.5"
-            style={{ background: 'var(--accent)' }}
+            role="button"
+            aria-label={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+            onClick={(e) => {
+              e.stopPropagation()
+              toggleFavorite(model.id)
+            }}
+            className="p-1 rounded-md transition-transform hover:scale-110 cursor-pointer"
+            title={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+            style={{ color: isFavorite ? '#fbbf24' : 'var(--text-secondary)' }}
           >
-            <Check size={11} color="white" />
+            <Star size={14} fill={isFavorite ? '#fbbf24' : 'none'} />
           </span>
-        )}
+          {selected && (
+            <span
+              className="w-5 h-5 rounded-full flex items-center justify-center"
+              style={{ background: 'var(--accent)' }}
+            >
+              <Check size={11} color="white" />
+            </span>
+          )}
+        </div>
       </div>
 
       <div className="flex items-center gap-3 mt-2 text-xs text-muted">

--- a/src/components/models/ModelPicker.tsx
+++ b/src/components/models/ModelPicker.tsx
@@ -12,6 +12,7 @@ import clsx from 'clsx'
 const CATEGORIES: { key: ModelCategory; label: string }[] = [
   { key: 'all', label: 'All' },
   { key: 'favorites', label: '⭐ Favorites' },
+  { key: 'recent', label: '🕒 Recent' },
   { key: 'coding', label: '💻 Coding' },
   { key: 'writing', label: '✍️ Writing' },
   { key: 'roleplay', label: '🎭 Roleplay' },
@@ -63,6 +64,7 @@ export function ModelPicker({ onClose, chatId, onSelectModel, currentModelIdOver
   const setDefaultModelId = useSettingsStore((s) => s.setDefaultModelId)
   const defaultModelId = useSettingsStore((s) => s.defaultModelId)
   const favoriteModelIds = useSettingsStore((s) => s.favoriteModelIds)
+  const recentModelIds = useSettingsStore((s) => s.recentModelIds)
 
   const updateChat = useChatStore((s) => s.updateChat)
   const chats = useChatStore((s) => s.chats)
@@ -118,6 +120,7 @@ export function ModelPicker({ onClose, chatId, onSelectModel, currentModelIdOver
     sortKey,
     category,
     favoriteIds: favoriteModelIds,
+    recentIds: recentModelIds,
   })
 
   return (
@@ -206,7 +209,9 @@ export function ModelPicker({ onClose, chatId, onSelectModel, currentModelIdOver
             <p className="text-center text-muted text-sm py-12">
               {category === 'favorites'
                 ? 'No favorites yet — tap the ⭐ on any model to pin it here.'
-                : 'No models match your search.'}
+                : category === 'recent'
+                  ? 'No recent models yet — start chatting and they’ll show up here.'
+                  : 'No models match your search.'}
             </p>
           )}
           {!isLoading && !error && filtered.length > 0 && (

--- a/src/components/models/ModelPicker.tsx
+++ b/src/components/models/ModelPicker.tsx
@@ -11,6 +11,7 @@ import clsx from 'clsx'
 
 const CATEGORIES: { key: ModelCategory; label: string }[] = [
   { key: 'all', label: 'All' },
+  { key: 'favorites', label: '⭐ Favorites' },
   { key: 'coding', label: '💻 Coding' },
   { key: 'writing', label: '✍️ Writing' },
   { key: 'roleplay', label: '🎭 Roleplay' },
@@ -34,9 +35,15 @@ interface ModelPickerProps {
   onClose: () => void
   /** If provided, selecting a model updates the chat rather than the default */
   chatId?: string | null
+  /** Override what happens on selection — used by AI character builder etc. */
+  onSelectModel?: (modelId: string) => void
+  /** Override the highlighted/current model id when onSelectModel is used */
+  currentModelIdOverride?: string
+  /** Optional title override */
+  title?: string
 }
 
-export function ModelPicker({ onClose, chatId }: ModelPickerProps) {
+export function ModelPicker({ onClose, chatId, onSelectModel, currentModelIdOverride, title }: ModelPickerProps) {
   const models = useModelStore((s) => s.models)
   const isLoading = useModelStore((s) => s.isLoading)
   const error = useModelStore((s) => s.error)
@@ -55,12 +62,14 @@ export function ModelPicker({ onClose, chatId }: ModelPickerProps) {
   const apiKey = useSettingsStore((s) => s.apiKey)
   const setDefaultModelId = useSettingsStore((s) => s.setDefaultModelId)
   const defaultModelId = useSettingsStore((s) => s.defaultModelId)
+  const favoriteModelIds = useSettingsStore((s) => s.favoriteModelIds)
 
   const updateChat = useChatStore((s) => s.updateChat)
   const chats = useChatStore((s) => s.chats)
-  const currentModelId = chatId
-    ? (chats.find((c) => c.id === chatId)?.modelId ?? defaultModelId)
-    : defaultModelId
+  const currentModelId = currentModelIdOverride
+    ?? (chatId
+      ? (chats.find((c) => c.id === chatId)?.modelId ?? defaultModelId)
+      : defaultModelId)
 
   const searchRef = useRef<HTMLInputElement>(null)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -94,7 +103,9 @@ export function ModelPicker({ onClose, chatId }: ModelPickerProps) {
   }
 
   function handleSelect(modelId: string) {
-    if (chatId) {
+    if (onSelectModel) {
+      onSelectModel(modelId)
+    } else if (chatId) {
       updateChat(chatId, { modelId })
     } else {
       setDefaultModelId(modelId)
@@ -102,7 +113,12 @@ export function ModelPicker({ onClose, chatId }: ModelPickerProps) {
     onClose()
   }
 
-  const filtered = filterAndSortModels(models, { searchQuery, sortKey, category })
+  const filtered = filterAndSortModels(models, {
+    searchQuery,
+    sortKey,
+    category,
+    favoriteIds: favoriteModelIds,
+  })
 
   return (
     <div
@@ -116,7 +132,7 @@ export function ModelPicker({ onClose, chatId }: ModelPickerProps) {
       >
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 border-b border-subtle shrink-0">
-          <h2 className="font-bold text-base">Select Model</h2>
+          <h2 className="font-bold text-base">{title ?? 'Select Model'}</h2>
           <div className="flex items-center gap-2">
             <button onClick={loadModels} className="btn-ghost p-1.5 rounded-lg" title="Refresh models">
               <RefreshCw size={15} className={isLoading ? 'animate-spin' : ''} />
@@ -187,7 +203,11 @@ export function ModelPicker({ onClose, chatId }: ModelPickerProps) {
             </div>
           )}
           {!isLoading && !error && filtered.length === 0 && (
-            <p className="text-center text-muted text-sm py-12">No models match your search.</p>
+            <p className="text-center text-muted text-sm py-12">
+              {category === 'favorites'
+                ? 'No favorites yet — tap the ⭐ on any model to pin it here.'
+                : 'No models match your search.'}
+            </p>
           )}
           {!isLoading && !error && filtered.length > 0 && (
             <div className="grid gap-2 sm:grid-cols-2">

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { X, Eye, EyeOff, Check, AlertCircle, Loader } from 'lucide-react'
+import { X, Eye, EyeOff, Check, AlertCircle, Loader, KeyRound } from 'lucide-react'
 import { useSettingsStore } from '../../store/settingsStore'
 import { fetchModels } from '../../api/openrouter'
 import { THEME_SWATCHES } from '../../types'
@@ -12,34 +12,111 @@ interface SettingsModalProps {
 
 type TestStatus = 'idle' | 'loading' | 'ok' | 'error'
 
-export function SettingsModal({ onClose }: SettingsModalProps) {
-  const apiKey = useSettingsStore((s) => s.apiKey)
-  const theme = useSettingsStore((s) => s.theme)
-  const setApiKey = useSettingsStore((s) => s.setApiKey)
-  const setTheme = useSettingsStore((s) => s.setTheme)
+interface ApiKeyFieldProps {
+  label: string
+  helper: React.ReactNode
+  value: string
+  onSave: (key: string) => void
+  placeholder?: string
+}
 
-  const [keyDraft, setKeyDraft] = useState(apiKey)
-  const [showKey, setShowKey] = useState(false)
-  const [testStatus, setTestStatus] = useState<TestStatus>('idle')
-  const [testMessage, setTestMessage] = useState('')
+function ApiKeyField({ label, helper, value, onSave, placeholder }: ApiKeyFieldProps) {
+  const [draft, setDraft] = useState(value)
+  const [show, setShow] = useState(false)
+  const [status, setStatus] = useState<TestStatus>('idle')
+  const [message, setMessage] = useState('')
 
   async function handleTest() {
-    if (!keyDraft.trim()) { setTestMessage('Enter an API key first.'); setTestStatus('error'); return }
-    setTestStatus('loading')
-    setTestMessage('')
+    if (!draft.trim()) {
+      setMessage('Enter a key first.')
+      setStatus('error')
+      return
+    }
+    setStatus('loading')
+    setMessage('')
     try {
-      const models = await fetchModels(keyDraft.trim())
-      setTestStatus('ok')
-      setTestMessage(`Connected! ${models.length} models available.`)
+      const models = await fetchModels(draft.trim())
+      setStatus('ok')
+      setMessage(`Connected! ${models.length} models available.`)
     } catch (e) {
-      setTestStatus('error')
-      setTestMessage((e as Error).message)
+      setStatus('error')
+      setMessage((e as Error).message)
     }
   }
 
-  function handleSaveKey() {
-    setApiKey(keyDraft.trim())
+  function handleSave() {
+    onSave(draft.trim())
   }
+
+  return (
+    <section>
+      <h3 className="font-semibold text-sm mb-3 flex items-center gap-2">
+        <KeyRound size={13} />
+        {label}
+      </h3>
+      <div className="flex gap-2 mb-2">
+        <div
+          className="flex items-center flex-1 rounded-lg border border-subtle overflow-hidden"
+          style={{ background: 'var(--bg-tertiary)' }}
+        >
+          <input
+            type={show ? 'text' : 'password'}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder={placeholder ?? 'sk-or-v1-…'}
+            className="flex-1 bg-transparent outline-none px-3 py-2 text-sm font-mono"
+            style={{ color: 'var(--text-primary)' }}
+            onKeyDown={(e) => e.key === 'Enter' && handleSave()}
+          />
+          <button
+            onClick={() => setShow((v) => !v)}
+            className="px-2 py-2 btn-ghost"
+            title={show ? 'Hide key' : 'Show key'}
+          >
+            {show ? <EyeOff size={14} /> : <Eye size={14} />}
+          </button>
+        </div>
+        <button onClick={handleSave} className="btn-primary text-sm px-3">
+          Save
+        </button>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          onClick={handleTest}
+          disabled={status === 'loading'}
+          className="flex items-center gap-1.5 text-xs btn-ghost border border-subtle px-3 py-1.5 rounded-lg"
+        >
+          {status === 'loading' ? (
+            <Loader size={12} className="animate-spin" />
+          ) : (
+            <span>Test Connection</span>
+          )}
+        </button>
+        {status === 'ok' && (
+          <span className="flex items-center gap-1 text-xs" style={{ color: '#22c55e' }}>
+            <Check size={12} /> {message}
+          </span>
+        )}
+        {status === 'error' && (
+          <span className="flex items-center gap-1 text-xs" style={{ color: 'var(--danger)' }}>
+            <AlertCircle size={12} /> {message}
+          </span>
+        )}
+      </div>
+
+      <div className="text-xs text-muted mt-2">{helper}</div>
+    </section>
+  )
+}
+
+export function SettingsModal({ onClose }: SettingsModalProps) {
+  const apiKey = useSettingsStore((s) => s.apiKey)
+  const builderApiKey = useSettingsStore((s) => s.builderApiKey)
+  const theme = useSettingsStore((s) => s.theme)
+  const setApiKey = useSettingsStore((s) => s.setApiKey)
+  const setBuilderApiKey = useSettingsStore((s) => s.setBuilderApiKey)
+  const setTheme = useSettingsStore((s) => s.setTheme)
 
   return (
     <div
@@ -48,77 +125,41 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
       onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
     >
       <div
-        className="w-full max-w-md rounded-2xl shadow-2xl fade-in overflow-hidden"
+        className="w-full max-w-md rounded-2xl shadow-2xl fade-in overflow-hidden max-h-[90vh] flex flex-col"
         style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border)' }}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-5 py-4 border-b border-subtle">
+        <div className="flex items-center justify-between px-5 py-4 border-b border-subtle shrink-0">
           <h2 className="font-bold text-base">⚙️ Settings</h2>
           <button onClick={onClose} className="btn-ghost p-1.5 rounded-lg">
             <X size={16} />
           </button>
         </div>
 
-        <div className="p-5 flex flex-col gap-6">
-          {/* API Key section */}
-          <section>
-            <h3 className="font-semibold text-sm mb-3">OpenRouter API Key</h3>
-            <div className="flex gap-2 mb-2">
-              <div
-                className="flex items-center flex-1 rounded-lg border border-subtle overflow-hidden"
-                style={{ background: 'var(--bg-tertiary)' }}
-              >
-                <input
-                  type={showKey ? 'text' : 'password'}
-                  value={keyDraft}
-                  onChange={(e) => setKeyDraft(e.target.value)}
-                  placeholder="sk-or-v1-…"
-                  className="flex-1 bg-transparent outline-none px-3 py-2 text-sm font-mono"
-                  style={{ color: 'var(--text-primary)' }}
-                  onKeyDown={(e) => e.key === 'Enter' && handleSaveKey()}
-                />
-                <button
-                  onClick={() => setShowKey((v) => !v)}
-                  className="px-2 py-2 btn-ghost"
-                  title={showKey ? 'Hide key' : 'Show key'}
-                >
-                  {showKey ? <EyeOff size={14} /> : <Eye size={14} />}
-                </button>
-              </div>
-              <button onClick={handleSaveKey} className="btn-primary text-sm px-3">
-                Save
-              </button>
-            </div>
+        <div className="p-5 flex flex-col gap-6 overflow-y-auto">
+          <ApiKeyField
+            label="OpenRouter API Key"
+            value={apiKey}
+            onSave={setApiKey}
+            helper={
+              <>
+                Get your key at <span className="accent-text">openrouter.ai/keys</span>.
+                Stored locally in your browser only.
+              </>
+            }
+          />
 
-            <div className="flex items-center gap-2">
-              <button
-                onClick={handleTest}
-                disabled={testStatus === 'loading'}
-                className="flex items-center gap-1.5 text-xs btn-ghost border border-subtle px-3 py-1.5 rounded-lg"
-              >
-                {testStatus === 'loading' ? (
-                  <Loader size={12} className="animate-spin" />
-                ) : (
-                  <span>Test Connection</span>
-                )}
-              </button>
-              {testStatus === 'ok' && (
-                <span className="flex items-center gap-1 text-xs" style={{ color: '#22c55e' }}>
-                  <Check size={12} /> {testMessage}
-                </span>
-              )}
-              {testStatus === 'error' && (
-                <span className="flex items-center gap-1 text-xs" style={{ color: 'var(--danger)' }}>
-                  <AlertCircle size={12} /> {testMessage}
-                </span>
-              )}
-            </div>
-
-            <p className="text-xs text-muted mt-2">
-              Get your key at{' '}
-              <span className="accent-text">openrouter.ai/keys</span>. Stored locally in your browser only.
-            </p>
-          </section>
+          <ApiKeyField
+            label="Builder API Key (optional)"
+            value={builderApiKey}
+            onSave={setBuilderApiKey}
+            helper={
+              <>
+                If set, AI Character Builder and Punch Up use this key.
+                Leave blank to fall back to your main key.
+              </>
+            }
+          />
 
           {/* Theme section */}
           <section>

--- a/src/hooks/useStreamingChat.ts
+++ b/src/hooks/useStreamingChat.ts
@@ -12,6 +12,7 @@ export function useStreamingChat() {
   const finalizeMessage = useChatStore((s) => s.finalizeMessage)
   const chats = useChatStore((s) => s.chats)
   const apiKey = useSettingsStore((s) => s.apiKey)
+  const pushRecentModel = useSettingsStore((s) => s.pushRecentModel)
 
   function cancelStream() {
     cancelRef.current?.()
@@ -22,6 +23,8 @@ export function useStreamingChat() {
   function sendMessage(chatId: string, userContent: string) {
     const chat = chats.find((c) => c.id === chatId)
     if (!chat) return
+
+    pushRecentModel(chat.modelId)
 
     // Cancel any in-progress stream
     cancelRef.current?.()

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -2,26 +2,35 @@ import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import type { ThemeName } from '../types'
 
+const RECENT_CAP = 8
+
 interface SettingsState {
   apiKey: string
+  builderApiKey: string
   theme: ThemeName
   defaultModelId: string
   favoriteModelIds: string[]
+  recentModelIds: string[]
   setApiKey: (key: string) => void
+  setBuilderApiKey: (key: string) => void
   setTheme: (theme: ThemeName) => void
   setDefaultModelId: (id: string) => void
   toggleFavoriteModel: (id: string) => void
   isFavoriteModel: (id: string) => boolean
+  pushRecentModel: (id: string) => void
 }
 
 export const useSettingsStore = create<SettingsState>()(
   persist(
     (set, get) => ({
       apiKey: '',
+      builderApiKey: '',
       theme: 'dark',
       defaultModelId: 'openai/gpt-4o-mini',
       favoriteModelIds: [],
+      recentModelIds: [],
       setApiKey: (key) => set({ apiKey: key }),
+      setBuilderApiKey: (key) => set({ builderApiKey: key }),
       setTheme: (theme) => {
         document.documentElement.setAttribute('data-theme', theme)
         set({ theme })
@@ -34,6 +43,10 @@ export const useSettingsStore = create<SettingsState>()(
             : [...s.favoriteModelIds, id],
         })),
       isFavoriteModel: (id) => get().favoriteModelIds.includes(id),
+      pushRecentModel: (id) =>
+        set((s) => ({
+          recentModelIds: [id, ...s.recentModelIds.filter((m) => m !== id)].slice(0, RECENT_CAP),
+        })),
     }),
     {
       name: 'jamba-settings',

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -6,23 +6,34 @@ interface SettingsState {
   apiKey: string
   theme: ThemeName
   defaultModelId: string
+  favoriteModelIds: string[]
   setApiKey: (key: string) => void
   setTheme: (theme: ThemeName) => void
   setDefaultModelId: (id: string) => void
+  toggleFavoriteModel: (id: string) => void
+  isFavoriteModel: (id: string) => boolean
 }
 
 export const useSettingsStore = create<SettingsState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       apiKey: '',
       theme: 'dark',
       defaultModelId: 'openai/gpt-4o-mini',
+      favoriteModelIds: [],
       setApiKey: (key) => set({ apiKey: key }),
       setTheme: (theme) => {
         document.documentElement.setAttribute('data-theme', theme)
         set({ theme })
       },
       setDefaultModelId: (id) => set({ defaultModelId: id }),
+      toggleFavoriteModel: (id) =>
+        set((s) => ({
+          favoriteModelIds: s.favoriteModelIds.includes(id)
+            ? s.favoriteModelIds.filter((m) => m !== id)
+            : [...s.favoriteModelIds, id],
+        })),
+      isFavoriteModel: (id) => get().favoriteModelIds.includes(id),
     }),
     {
       name: 'jamba-settings',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -53,6 +53,7 @@ export interface Prompt {
 export type ModelCategory =
   | 'all'
   | 'favorites'
+  | 'recent'
   | 'coding'
   | 'writing'
   | 'roleplay'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -52,6 +52,7 @@ export interface Prompt {
 
 export type ModelCategory =
   | 'all'
+  | 'favorites'
   | 'coding'
   | 'writing'
   | 'roleplay'

--- a/src/utils/modelFilters.ts
+++ b/src/utils/modelFilters.ts
@@ -50,12 +50,15 @@ export interface FilterOptions {
   sortKey: ModelSortKey
   category: ModelCategory
   favoriteIds?: string[]
+  recentIds?: string[]
 }
 
 export function filterAndSortModels(models: Model[], opts: FilterOptions): Model[] {
-  const { searchQuery, sortKey, category, favoriteIds } = opts
+  const { searchQuery, sortKey, category, favoriteIds, recentIds } = opts
   const q = searchQuery.toLowerCase().trim()
   const favSet = new Set(favoriteIds ?? [])
+  const recentList = recentIds ?? []
+  const recentIndex = new Map(recentList.map((id, i) => [id, i] as const))
 
   let filtered = models.filter((m) => {
     if (q && !m.id.toLowerCase().includes(q) && !m.name.toLowerCase().includes(q)) {
@@ -63,11 +66,20 @@ export function filterAndSortModels(models: Model[], opts: FilterOptions): Model
     }
     if (category === 'favorites') {
       if (!favSet.has(m.id)) return false
+    } else if (category === 'recent') {
+      if (!recentIndex.has(m.id)) return false
     } else if (category !== 'all') {
       if (detectCategory(m) !== category) return false
     }
     return true
   })
+
+  // Recent tab preserves usage order regardless of selected sortKey
+  if (category === 'recent') {
+    return [...filtered].sort(
+      (a, b) => (recentIndex.get(a.id) ?? 0) - (recentIndex.get(b.id) ?? 0)
+    )
+  }
 
   filtered = [...filtered].sort((a, b) => {
     switch (sortKey) {

--- a/src/utils/modelFilters.ts
+++ b/src/utils/modelFilters.ts
@@ -1,10 +1,19 @@
 import type { Model, ModelCategory, ModelSortKey } from '../types'
 
 const CODING_KW = ['code', 'coder', 'codex', 'starcoder', 'deepseek-coder', 'wizard-code', 'coding', 'deepseekcoder', 'codellama', 'code-llama', 'qwen-coder', 'qwencoder', 'devstral']
-const WRITING_KW = ['creative', 'story', 'novelist', 'mythomax', 'claude', 'gpt-4', 'writing', 'writer', 'llama-3.3', 'gemini']
-const ROLEPLAY_KW = ['rp', 'roleplay', 'mytho', 'nous', 'pygmalion', 'stheno', 'hermes', 'noromaid', 'airoboros', 'dolphin']
+const WRITING_KW = ['creative', 'story', 'novelist', 'mythomax', 'claude', 'gpt-4', 'writing', 'writer', 'llama-3.3', 'gemini', 'unslop', 'rocinante']
+const ROLEPLAY_KW = ['rp', 'roleplay', 'mytho', 'nous', 'pygmalion', 'stheno', 'hermes', 'noromaid', 'airoboros', 'dolphin', 'magnum', 'lumimaid', 'euryale', 'hanami', 'mythalion', 'nothingiisreal']
 const REASONING_KW = ['o1', 'thinking', 'reason', 'qwq', 'r1', 'deepseek-r1', 'reasoning', 'reflection']
-const UNCENSORED_KW = ['uncensored', 'nsfw', 'adult', 'abliterated']
+const UNCENSORED_KW = [
+  'uncensored', 'nsfw', 'adult', 'abliterated',
+  'venice', 'dolphin-mistral', 'dolphin-2', 'dolphin-3',
+  'lumimaid', 'euryale', 'hanami', 'stheno',
+  'magnum', 'rocinante', 'unslop', 'unslopnemo',
+  'cydonia', 'valkyrie', 'skyfall', 'behemoth',
+  'mlewd', 'mythomax', 'mythalion', 'noromaid', 'pygmalion',
+  'thedrummer', 'sao10k', 'anthracite', 'neversleep', 'nothingiisreal',
+  'cognitivecomputations', 'wizardlm-uncensored',
+]
 
 export function detectCategory(model: Model): ModelCategory {
   const haystack = (model.id + ' ' + model.name).toLowerCase()
@@ -40,17 +49,23 @@ export interface FilterOptions {
   searchQuery: string
   sortKey: ModelSortKey
   category: ModelCategory
+  favoriteIds?: string[]
 }
 
 export function filterAndSortModels(models: Model[], opts: FilterOptions): Model[] {
-  const { searchQuery, sortKey, category } = opts
+  const { searchQuery, sortKey, category, favoriteIds } = opts
   const q = searchQuery.toLowerCase().trim()
+  const favSet = new Set(favoriteIds ?? [])
 
   let filtered = models.filter((m) => {
     if (q && !m.id.toLowerCase().includes(q) && !m.name.toLowerCase().includes(q)) {
       return false
     }
-    if (category !== 'all' && detectCategory(m) !== category) return false
+    if (category === 'favorites') {
+      if (!favSet.has(m.id)) return false
+    } else if (category !== 'all') {
+      if (detectCategory(m) !== category) return false
+    }
     return true
   })
 


### PR DESCRIPTION
- Favorites: star toggle on ModelCard, persisted favoriteModelIds in
  settingsStore, new "⭐ Favorites" tab in ModelPicker
- Uncensored coverage: extend keyword list with venice, dolphin-mistral,
  lumimaid, euryale, magnum, rocinante, unslopnemo, cydonia, valkyrie,
  skyfall, behemoth, mythalion, noromaid, thedrummer, sao10k, anthracite,
  neversleep, nothingiisreal, etc.
- AI character builder: new AICharacterBuilder modal lets user pick any
  OpenRouter model (reusing ModelPicker via new onSelectModel callback),
  describe a character, and have the model draft a full Character JSON
  (name, emoji, color, tags, description, systemPrompt) which is parsed
  and seeded into the regular form for review/edit before saving.
- ModelPicker: new optional onSelectModel/currentModelIdOverride/title
  props so it can be reused for non-default selection contexts.
- API: completeChat() non-streaming helper added to openrouter client.