### PR TITLE
Add 13 new features: editing, bookmarks, image uploads, pinned chats, search, branching, import, more exports, keyboard shortcuts, custom themes, idle animations, token counter, and regenerate

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,31 +1,89 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { AppLayout } from './components/layout/AppLayout'
 import { ChatView } from './components/chat/ChatView'
 import { ModelPicker } from './components/models/ModelPicker'
 import { PromptLibrary } from './components/prompts/PromptLibrary'
 import { CharacterSelector } from './components/characters/CharacterSelector'
 import { SettingsModal } from './components/settings/SettingsModal'
+import { BookmarksPanel } from './components/bookmarks/BookmarksPanel'
 import { Starfield } from './components/Starfield'
 import { useIdleTimer } from './hooks/useIdleTimer'
 import { useChatStore } from './store/chatStore'
+import { useSettingsStore } from './store/settingsStore'
 
 export default function App() {
   const [showSettings, setShowSettings] = useState(false)
   const [showModelPicker, setShowModelPicker] = useState(false)
   const [showPrompts, setShowPrompts] = useState(false)
   const [showCharacters, setShowCharacters] = useState(false)
+  const [showBookmarks, setShowBookmarks] = useState(false)
   const [isIdle, setIsIdle] = useState(false)
 
   const activeChatId = useChatStore((s) => s.activeChatId)
+  const createChat = useChatStore((s) => s.createChat)
+  const setActiveChatId = useChatStore((s) => s.setActiveChatId)
+  const idleAnimation = useSettingsStore((s) => s.idleAnimation)
+  const defaultModelId = useSettingsStore((s) => s.defaultModelId)
+  const apiKey = useSettingsStore((s) => s.apiKey)
 
   const handleIdle = useCallback(() => setIsIdle(true), [])
   const handleActive = useCallback(() => setIsIdle(false), [])
 
   useIdleTimer(15_000, handleIdle, handleActive)
 
+  // Global keyboard shortcuts
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      const ctrl = e.ctrlKey || e.metaKey
+      // Don't fire when typing in an input/textarea
+      const tag = (e.target as HTMLElement).tagName.toLowerCase()
+      const isInput = tag === 'input' || tag === 'textarea'
+
+      if (e.key === 'Escape') {
+        setShowSettings(false)
+        setShowModelPicker(false)
+        setShowPrompts(false)
+        setShowCharacters(false)
+        setShowBookmarks(false)
+        setIsIdle(false)
+        return
+      }
+
+      if (ctrl && !isInput) {
+        if (e.key === 'k' || e.key === 'K') {
+          e.preventDefault()
+          setShowModelPicker((v) => !v)
+        } else if (e.key === 'n' || e.key === 'N') {
+          e.preventDefault()
+          if (apiKey) createChat(defaultModelId)
+          else setShowSettings(true)
+        } else if (e.key === '/') {
+          e.preventDefault()
+          setShowPrompts((v) => !v)
+        } else if (e.key === 'b' || e.key === 'B') {
+          e.preventDefault()
+          setShowBookmarks((v) => !v)
+        } else if (e.key === ',') {
+          e.preventDefault()
+          setShowSettings((v) => !v)
+        }
+      }
+    }
+
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [apiKey, createChat, defaultModelId])
+
+  function handleNavigateToChat(chatId: string) {
+    setActiveChatId(chatId)
+  }
+
   return (
     <>
-      <AppLayout onOpenSettings={() => setShowSettings(true)}>
+      <AppLayout
+        onOpenSettings={() => setShowSettings(true)}
+        onOpenBookmarks={() => setShowBookmarks(true)}
+      >
         <ChatView
           onOpenModelPicker={() => setShowModelPicker(true)}
           onOpenPrompts={() => setShowPrompts(true)}
@@ -34,19 +92,27 @@ export default function App() {
         />
       </AppLayout>
 
-      {/* Modals & panels */}
+      {/* Modals */}
       {showSettings && <SettingsModal onClose={() => setShowSettings(false)} />}
       {showModelPicker && (
-        <ModelPicker
-          onClose={() => setShowModelPicker(false)}
-          chatId={activeChatId}
-        />
+        <ModelPicker onClose={() => setShowModelPicker(false)} chatId={activeChatId} />
       )}
       {showPrompts && <PromptLibrary onClose={() => setShowPrompts(false)} />}
       {showCharacters && <CharacterSelector onClose={() => setShowCharacters(false)} />}
+      {showBookmarks && (
+        <BookmarksPanel
+          onClose={() => setShowBookmarks(false)}
+          onNavigateToChat={handleNavigateToChat}
+        />
+      )}
 
-      {/* Starfield idle animation */}
-      {isIdle && <Starfield onDismiss={() => setIsIdle(false)} />}
+      {/* Idle animation */}
+      {isIdle && (
+        <Starfield
+          onDismiss={() => setIsIdle(false)}
+          animationType={idleAnimation}
+        />
+      )}
     </>
   )
 }

--- a/src/api/openrouter.ts
+++ b/src/api/openrouter.ts
@@ -7,7 +7,7 @@ function headers(apiKey: string): Record<string, string> {
     Authorization: `Bearer ${apiKey}`,
     'Content-Type': 'application/json',
     'HTTP-Referer': window.location.origin,
-    'X-Title': 'Jamba',
+    'X-Title': 'OpenStarChat',
   }
 }
 
@@ -23,10 +23,32 @@ export async function fetchModels(apiKey: string): Promise<Model[]> {
   return (data.data as Model[]) ?? []
 }
 
+export type ApiMessagePart =
+  | { type: 'text'; text: string }
+  | { type: 'image_url'; image_url: { url: string } }
+
+export type ApiMessage = {
+  role: 'user' | 'assistant' | 'system'
+  content: string | ApiMessagePart[]
+}
+
+function buildApiMessage(msg: Pick<Message, 'role' | 'content' | 'imageUrl'>): ApiMessage {
+  if (msg.role === 'user' && msg.imageUrl) {
+    return {
+      role: 'user',
+      content: [
+        { type: 'image_url', image_url: { url: msg.imageUrl } },
+        { type: 'text', text: msg.content },
+      ],
+    }
+  }
+  return { role: msg.role, content: msg.content }
+}
+
 export interface CompleteChatOptions {
   apiKey: string
   modelId: string
-  messages: Pick<Message, 'role' | 'content'>[]
+  messages: Pick<Message, 'role' | 'content' | 'imageUrl'>[]
   systemPrompt?: string
   signal?: AbortSignal
   temperature?: number
@@ -34,6 +56,10 @@ export interface CompleteChatOptions {
 
 export async function completeChat(opts: CompleteChatOptions): Promise<string> {
   const { apiKey, modelId, messages, systemPrompt, signal, temperature } = opts
+  const apiMessages: ApiMessage[] = systemPrompt
+    ? [{ role: 'system', content: systemPrompt }, ...messages.map(buildApiMessage)]
+    : messages.map(buildApiMessage)
+
   const res = await fetch(`${BASE_URL}/chat/completions`, {
     method: 'POST',
     headers: headers(apiKey),
@@ -42,9 +68,7 @@ export async function completeChat(opts: CompleteChatOptions): Promise<string> {
       model: modelId,
       stream: false,
       ...(temperature !== undefined ? { temperature } : {}),
-      messages: systemPrompt
-        ? [{ role: 'system', content: systemPrompt }, ...messages]
-        : [...messages],
+      messages: apiMessages,
     }),
   })
   if (!res.ok) {
@@ -62,10 +86,10 @@ export async function completeChat(opts: CompleteChatOptions): Promise<string> {
 export type StreamChatOptions = {
   apiKey: string
   modelId: string
-  messages: Pick<Message, 'role' | 'content'>[]
+  messages: Pick<Message, 'role' | 'content' | 'imageUrl'>[]
   systemPrompt?: string
   onDelta: (delta: string) => void
-  onDone: () => void
+  onDone: (tokenCount?: number) => void
   onError: (err: Error) => void
 }
 
@@ -73,17 +97,9 @@ export function streamChat(opts: StreamChatOptions): () => void {
   const { apiKey, modelId, messages, systemPrompt, onDelta, onDone, onError } = opts
   const controller = new AbortController()
 
-  const payload: {
-    model: string
-    messages: { role: string; content: string }[]
-    stream: boolean
-  } = {
-    model: modelId,
-    stream: true,
-    messages: systemPrompt
-      ? [{ role: 'system', content: systemPrompt }, ...messages]
-      : [...messages],
-  }
+  const apiMessages: ApiMessage[] = systemPrompt
+    ? [{ role: 'system', content: systemPrompt }, ...messages.map(buildApiMessage)]
+    : messages.map(buildApiMessage)
 
   ;(async () => {
     let res: Response
@@ -91,7 +107,7 @@ export function streamChat(opts: StreamChatOptions): () => void {
       res = await fetch(`${BASE_URL}/chat/completions`, {
         method: 'POST',
         headers: headers(apiKey),
-        body: JSON.stringify(payload),
+        body: JSON.stringify({ model: modelId, stream: true, messages: apiMessages }),
         signal: controller.signal,
       })
     } catch (err) {
@@ -108,12 +124,13 @@ export function streamChat(opts: StreamChatOptions): () => void {
     const reader = res.body!.getReader()
     const decoder = new TextDecoder()
     let buffer = ''
+    let totalChars = 0
 
     try {
       while (true) {
         const { done, value } = await reader.read()
         if (done) {
-          onDone()
+          onDone(Math.ceil(totalChars / 4))
           break
         }
 
@@ -126,13 +143,14 @@ export function streamChat(opts: StreamChatOptions): () => void {
           if (!trimmed.startsWith('data: ')) continue
           const data = trimmed.slice(6)
           if (data === '[DONE]') {
-            onDone()
+            onDone(Math.ceil(totalChars / 4))
             return
           }
           try {
             const parsed = JSON.parse(data)
             const delta = parsed.choices?.[0]?.delta?.content
             if (typeof delta === 'string' && delta) {
+              totalChars += delta.length
               onDelta(delta)
             }
           } catch {

--- a/src/components/Starfield.tsx
+++ b/src/components/Starfield.tsx
@@ -1,21 +1,18 @@
 import { useEffect, useRef } from 'react'
-
-interface Star {
-  x: number
-  y: number
-  size: number
-  opacity: number
-  opacityDir: 1 | -1
-  opacitySpeed: number
-  vx: number
-  vy: number
-}
+import type { IdleAnimation } from '../types'
 
 interface StarfieldProps {
   onDismiss: () => void
+  animationType: IdleAnimation
 }
 
-const STAR_COUNT = 160
+// ── Starfield ────────────────────────────────────────────────────────────────
+
+interface Star {
+  x: number; y: number; size: number
+  opacity: number; opacityDir: 1 | -1; opacitySpeed: number
+  vx: number; vy: number
+}
 
 function randomStar(w: number, h: number): Star {
   return {
@@ -30,15 +27,189 @@ function randomStar(w: number, h: number): Star {
   }
 }
 
-export function Starfield({ onDismiss }: StarfieldProps) {
+function drawStarfield(canvas: HTMLCanvasElement): () => void {
+  const ctx = canvas.getContext('2d')!
+  const stars: Star[] = Array.from({ length: 160 }, () => randomStar(canvas.width, canvas.height))
+  let raf = 0
+
+  function draw() {
+    const w = canvas.width; const h = canvas.height
+    ctx.clearRect(0, 0, w, h)
+    for (const s of stars) {
+      s.opacity += s.opacityDir * s.opacitySpeed
+      if (s.opacity >= 1) { s.opacity = 1; s.opacityDir = -1 }
+      if (s.opacity <= 0.05) { s.opacity = 0.05; s.opacityDir = 1 }
+      s.x += s.vx; s.y += s.vy
+      if (s.x < -5) s.x = w + 5; if (s.x > w + 5) s.x = -5
+      if (s.y < -5) s.y = h + 5; if (s.y > h + 5) s.y = -5
+      ctx.beginPath()
+      ctx.arc(s.x, s.y, s.size / 2, 0, Math.PI * 2)
+      ctx.fillStyle = `rgba(255,255,255,${s.opacity})`
+      ctx.fill()
+    }
+    raf = requestAnimationFrame(draw)
+  }
+
+  raf = requestAnimationFrame(draw)
+  return () => cancelAnimationFrame(raf)
+}
+
+// ── Shooting stars ───────────────────────────────────────────────────────────
+
+interface Shooter {
+  x: number; y: number; len: number; speed: number; angle: number; opacity: number; life: number; maxLife: number
+}
+
+function drawShootingStars(canvas: HTMLCanvasElement): () => void {
+  const ctx = canvas.getContext('2d')!
+  const bg: Star[] = Array.from({ length: 80 }, () => randomStar(canvas.width, canvas.height))
+  const shooters: Shooter[] = []
+  let raf = 0
+  let frame = 0
+
+  function spawnShooter() {
+    const angle = Math.PI / 4 + (Math.random() - 0.5) * 0.5
+    shooters.push({
+      x: Math.random() * canvas.width,
+      y: Math.random() * canvas.height * 0.5,
+      len: 80 + Math.random() * 120,
+      speed: 8 + Math.random() * 12,
+      angle,
+      opacity: 1,
+      life: 0,
+      maxLife: 40 + Math.random() * 30,
+    })
+  }
+
+  function draw() {
+    const w = canvas.width; const h = canvas.height
+    ctx.clearRect(0, 0, w, h)
+
+    // Background stars
+    for (const s of bg) {
+      s.opacity += s.opacityDir * s.opacitySpeed
+      if (s.opacity >= 1) { s.opacity = 1; s.opacityDir = -1 }
+      if (s.opacity <= 0.05) { s.opacity = 0.05; s.opacityDir = 1 }
+      ctx.beginPath()
+      ctx.arc(s.x, s.y, s.size / 2, 0, Math.PI * 2)
+      ctx.fillStyle = `rgba(255,255,255,${s.opacity * 0.6})`
+      ctx.fill()
+    }
+
+    // Spawn new shooter every ~90 frames
+    frame++
+    if (frame % 90 === 0) spawnShooter()
+
+    for (let i = shooters.length - 1; i >= 0; i--) {
+      const s = shooters[i]
+      s.life++
+      s.x += Math.cos(s.angle) * s.speed
+      s.y += Math.sin(s.angle) * s.speed
+      const t = s.life / s.maxLife
+      s.opacity = t < 0.2 ? t / 0.2 : 1 - (t - 0.2) / 0.8
+
+      const grad = ctx.createLinearGradient(
+        s.x, s.y,
+        s.x - Math.cos(s.angle) * s.len, s.y - Math.sin(s.angle) * s.len
+      )
+      grad.addColorStop(0, `rgba(255,255,255,${s.opacity})`)
+      grad.addColorStop(1, 'rgba(255,255,255,0)')
+      ctx.beginPath()
+      ctx.moveTo(s.x, s.y)
+      ctx.lineTo(s.x - Math.cos(s.angle) * s.len, s.y - Math.sin(s.angle) * s.len)
+      ctx.strokeStyle = grad
+      ctx.lineWidth = 1.5
+      ctx.stroke()
+
+      if (s.life >= s.maxLife || s.x > w + 200 || s.y > h + 200) {
+        shooters.splice(i, 1)
+      }
+    }
+
+    raf = requestAnimationFrame(draw)
+  }
+
+  spawnShooter()
+  raf = requestAnimationFrame(draw)
+  return () => cancelAnimationFrame(raf)
+}
+
+// ── Aurora ───────────────────────────────────────────────────────────────────
+
+function drawAurora(canvas: HTMLCanvasElement): () => void {
+  const ctx = canvas.getContext('2d')!
+  const bg: Star[] = Array.from({ length: 120 }, () => randomStar(canvas.width, canvas.height))
+  let raf = 0
+  let t = 0
+
+  // Aurora color bands
+  const colors = [
+    [0, 255, 128],
+    [0, 180, 255],
+    [180, 80, 255],
+    [0, 255, 200],
+  ]
+
+  function draw() {
+    const w = canvas.width; const h = canvas.height
+    ctx.clearRect(0, 0, w, h)
+    t += 0.008
+
+    // Background stars (dimmed)
+    for (const s of bg) {
+      s.opacity += s.opacityDir * s.opacitySpeed * 0.5
+      if (s.opacity >= 0.6) { s.opacity = 0.6; s.opacityDir = -1 }
+      if (s.opacity <= 0.05) { s.opacity = 0.05; s.opacityDir = 1 }
+      ctx.beginPath()
+      ctx.arc(s.x, s.y, s.size / 2, 0, Math.PI * 2)
+      ctx.fillStyle = `rgba(255,255,255,${s.opacity})`
+      ctx.fill()
+    }
+
+    // Draw aurora bands at bottom third
+    for (let b = 0; b < colors.length; b++) {
+      const [r, g, bl] = colors[b]
+      const offset = b * 0.7 + t
+      const yBase = h * 0.55 + Math.sin(offset * 0.8) * h * 0.08
+
+      ctx.save()
+      const grad = ctx.createLinearGradient(0, yBase - h * 0.12, 0, yBase + h * 0.2)
+      grad.addColorStop(0, `rgba(${r},${g},${bl},0)`)
+      grad.addColorStop(0.3, `rgba(${r},${g},${bl},0.18)`)
+      grad.addColorStop(0.7, `rgba(${r},${g},${bl},0.08)`)
+      grad.addColorStop(1, `rgba(${r},${g},${bl},0)`)
+
+      ctx.beginPath()
+      ctx.moveTo(0, yBase)
+      const waves = 6
+      for (let i = 0; i <= waves; i++) {
+        const x = (w / waves) * i
+        const y = yBase + Math.sin(i * 1.2 + t + b) * h * 0.04
+        i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y)
+      }
+      ctx.lineTo(w, yBase + h * 0.25)
+      ctx.lineTo(0, yBase + h * 0.25)
+      ctx.closePath()
+      ctx.fillStyle = grad
+      ctx.fill()
+      ctx.restore()
+    }
+
+    raf = requestAnimationFrame(draw)
+  }
+
+  raf = requestAnimationFrame(draw)
+  return () => cancelAnimationFrame(raf)
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export function Starfield({ onDismiss, animationType }: StarfieldProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
-  const starsRef = useRef<Star[]>([])
-  const rafRef = useRef<number | null>(null)
 
   useEffect(() => {
     const canvas = canvasRef.current
     if (!canvas) return
-    const ctx = canvas.getContext('2d')!
 
     function resize() {
       canvas!.width = window.innerWidth
@@ -47,55 +218,31 @@ export function Starfield({ onDismiss }: StarfieldProps) {
     resize()
     window.addEventListener('resize', resize)
 
-    starsRef.current = Array.from({ length: STAR_COUNT }, () =>
-      randomStar(canvas.width, canvas.height)
-    )
+    const type = animationType === 'random'
+      ? (['starfield', 'shooting', 'aurora'] as const)[Math.floor(Math.random() * 3)]
+      : animationType
 
-    function draw() {
-      const w = canvas!.width
-      const h = canvas!.height
-      ctx.clearRect(0, 0, w, h)
-
-      for (const star of starsRef.current) {
-        // Update opacity (pulsing)
-        star.opacity += star.opacityDir * star.opacitySpeed
-        if (star.opacity >= 1) { star.opacity = 1; star.opacityDir = -1 }
-        if (star.opacity <= 0.05) { star.opacity = 0.05; star.opacityDir = 1 }
-
-        // Update position (gentle drift)
-        star.x += star.vx
-        star.y += star.vy
-
-        // Wrap around edges
-        if (star.x < -5) star.x = w + 5
-        if (star.x > w + 5) star.x = -5
-        if (star.y < -5) star.y = h + 5
-        if (star.y > h + 5) star.y = -5
-
-        ctx.beginPath()
-        ctx.arc(star.x, star.y, star.size / 2, 0, Math.PI * 2)
-        ctx.fillStyle = `rgba(255, 255, 255, ${star.opacity})`
-        ctx.fill()
-      }
-
-      rafRef.current = requestAnimationFrame(draw)
+    let cleanup: () => void
+    if (type === 'shooting') {
+      cleanup = drawShootingStars(canvas)
+    } else if (type === 'aurora') {
+      cleanup = drawAurora(canvas)
+    } else {
+      cleanup = drawStarfield(canvas)
     }
-
-    rafRef.current = requestAnimationFrame(draw)
 
     return () => {
-      if (rafRef.current) cancelAnimationFrame(rafRef.current)
+      cleanup()
       window.removeEventListener('resize', resize)
     }
-  }, [])
+  }, [animationType])
 
   return (
     <canvas
       ref={canvasRef}
       className="fixed inset-0 z-30"
-      style={{ cursor: 'pointer' }}
+      style={{ cursor: 'pointer', background: '#000' }}
       onClick={onDismiss}
-      onKeyDown={onDismiss}
     />
   )
 }

--- a/src/components/bookmarks/BookmarksPanel.tsx
+++ b/src/components/bookmarks/BookmarksPanel.tsx
@@ -1,0 +1,89 @@
+import { X, Bookmark, MessageSquare } from 'lucide-react'
+import { useChatStore } from '../../store/chatStore'
+
+interface BookmarksPanelProps {
+  onClose: () => void
+  onNavigateToChat: (chatId: string) => void
+}
+
+export function BookmarksPanel({ onClose, onNavigateToChat }: BookmarksPanelProps) {
+  const chats = useChatStore((s) => s.chats)
+  const toggleBookmarkMessage = useChatStore((s) => s.toggleBookmarkMessage)
+
+  const bookmarked = chats.flatMap((chat) =>
+    chat.messages
+      .filter((m) => m.bookmarked && m.role !== 'system')
+      .map((m) => ({ chat, message: m }))
+  ).sort((a, b) => b.message.createdAt - a.message.createdAt)
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ background: 'rgba(0,0,0,0.65)' }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div
+        className="w-full max-w-lg rounded-2xl shadow-2xl fade-in overflow-hidden max-h-[85vh] flex flex-col"
+        style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border)' }}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-subtle shrink-0">
+          <h2 className="font-bold text-base flex items-center gap-2">
+            <Bookmark size={16} className="accent-text" />
+            Bookmarked Messages
+          </h2>
+          <button onClick={onClose} className="btn-ghost p-1.5 rounded-lg"><X size={16} /></button>
+        </div>
+
+        <div className="overflow-y-auto flex-1">
+          {bookmarked.length === 0 ? (
+            <div className="flex flex-col items-center justify-center gap-3 py-16 text-muted">
+              <Bookmark size={32} className="opacity-30" />
+              <p className="text-sm">No bookmarks yet.</p>
+              <p className="text-xs opacity-70">Hover over any message and click the bookmark icon.</p>
+            </div>
+          ) : (
+            <div className="divide-y" style={{ borderColor: 'var(--border)' }}>
+              {bookmarked.map(({ chat, message }) => (
+                <div key={message.id} className="p-4 group hover:bg-tertiary transition-colors" style={{ background: 'transparent' }}>
+                  <div className="flex items-start justify-between gap-3 mb-2">
+                    <button
+                      onClick={() => { onNavigateToChat(chat.id); onClose() }}
+                      className="flex items-center gap-1.5 text-xs btn-ghost px-2 py-0.5 rounded-md"
+                      title="Go to chat"
+                    >
+                      <MessageSquare size={11} />
+                      <span className="truncate max-w-[200px]">{chat.title}</span>
+                    </button>
+                    <div className="flex items-center gap-2 shrink-0">
+                      <span className="text-xs text-muted">
+                        {message.role === 'user' ? 'You' : 'AI'}
+                      </span>
+                      <button
+                        onClick={() => toggleBookmarkMessage(chat.id, message.id)}
+                        className="p-1 btn-ghost rounded opacity-0 group-hover:opacity-100 transition-opacity"
+                        title="Remove bookmark"
+                        style={{ color: 'var(--accent)' }}
+                      >
+                        <X size={12} />
+                      </button>
+                    </div>
+                  </div>
+                  <p
+                    className="text-sm leading-relaxed line-clamp-4 whitespace-pre-wrap"
+                    style={{ color: 'var(--text-primary)' }}
+                  >
+                    {message.content}
+                  </p>
+                  <p className="text-xs text-muted mt-1.5">
+                    {new Date(message.createdAt).toLocaleString()}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -1,5 +1,5 @@
-import { useRef, useEffect } from 'react'
-import { Send, Square, ChevronDown } from 'lucide-react'
+import { useRef, useEffect, useState } from 'react'
+import { Send, Square, ChevronDown, Paperclip, X } from 'lucide-react'
 import clsx from 'clsx'
 import type { Chat, Character } from '../../types'
 
@@ -7,7 +7,7 @@ interface ChatInputProps {
   chat: Chat
   character: Character | null
   isStreaming: boolean
-  onSend: (content: string) => void
+  onSend: (content: string, imageUrl?: string) => void
   onCancel: () => void
   onOpenModelPicker: () => void
   onOpenCharacters: () => void
@@ -23,6 +23,9 @@ export function ChatInput({
   onOpenCharacters,
 }: ChatInputProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [attachedImage, setAttachedImage] = useState<string | null>(null)
+  const [attachedName, setAttachedName] = useState<string>('')
 
   useEffect(() => {
     if (textareaRef.current) {
@@ -40,12 +43,27 @@ export function ChatInput({
 
   function submit() {
     const val = textareaRef.current?.value.trim()
-    if (!val || isStreaming) return
+    if ((!val && !attachedImage) || isStreaming) return
     if (textareaRef.current) textareaRef.current.value = ''
-    onSend(val)
+    const img = attachedImage ?? undefined
+    setAttachedImage(null)
+    setAttachedName('')
+    onSend(val ?? '', img)
   }
 
-  // Extract provider from model id like "openai/gpt-4o" → "openai"
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    if (!file.type.startsWith('image/')) return
+    const reader = new FileReader()
+    reader.onload = () => {
+      setAttachedImage(reader.result as string)
+      setAttachedName(file.name)
+    }
+    reader.readAsDataURL(file)
+    e.target.value = ''
+  }
+
   const modelParts = chat.modelId.split('/')
   const provider = modelParts[0] ?? ''
   const modelShort = modelParts.slice(1).join('/') || chat.modelId
@@ -55,7 +73,7 @@ export function ChatInput({
       className="border-t border-subtle p-3"
       style={{ background: 'var(--bg-secondary)' }}
     >
-      {/* Context bar: model + character */}
+      {/* Context bar */}
       <div className="flex items-center gap-2 mb-2 flex-wrap">
         <button
           onClick={onOpenModelPicker}
@@ -99,11 +117,42 @@ export function ChatInput({
         )}
       </div>
 
+      {/* Image preview */}
+      {attachedImage && (
+        <div className="flex items-center gap-2 mb-2 px-1">
+          <img src={attachedImage} alt="Attachment preview" className="h-12 w-12 object-cover rounded-lg border border-subtle" />
+          <span className="text-xs text-muted truncate flex-1">{attachedName}</span>
+          <button
+            onClick={() => { setAttachedImage(null); setAttachedName('') }}
+            className="btn-ghost p-1 rounded"
+            title="Remove image"
+          >
+            <X size={13} />
+          </button>
+        </div>
+      )}
+
       {/* Input row */}
       <div
         className="flex items-end gap-2 rounded-xl border border-subtle p-2"
         style={{ background: 'var(--bg-tertiary)' }}
       >
+        <button
+          onClick={() => fileInputRef.current?.click()}
+          className="shrink-0 p-1.5 rounded-lg btn-ghost"
+          title="Attach image"
+          disabled={isStreaming}
+        >
+          <Paperclip size={15} />
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={handleFileChange}
+        />
+
         <textarea
           ref={textareaRef}
           rows={1}
@@ -113,6 +162,7 @@ export function ChatInput({
           className="flex-1 bg-transparent outline-none resize-none text-sm leading-relaxed min-h-[1.5rem] max-h-[200px]"
           style={{ color: 'var(--text-primary)' }}
         />
+
         {isStreaming ? (
           <button
             onClick={onCancel}
@@ -126,7 +176,7 @@ export function ChatInput({
           <button
             onClick={submit}
             className="shrink-0 p-2 rounded-lg btn-primary"
-            title="Send"
+            title="Send (Enter)"
           >
             <Send size={14} />
           </button>

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -23,8 +23,9 @@ export function ChatView({
   const activeChatId = useChatStore((s) => s.activeChatId)
   const characters = useChatStore((s) => s.characters)
   const createChat = useChatStore((s) => s.createChat)
+  const toggleBookmarkMessage = useChatStore((s) => s.toggleBookmarkMessage)
+  const branchChat = useChatStore((s) => s.branchChat)
   const defaultModelId = useChatStore(() => {
-    // read from settings store directly
     const stored = localStorage.getItem('jamba-settings')
     if (stored) {
       try {
@@ -36,7 +37,7 @@ export function ChatView({
     return 'openai/gpt-4o-mini'
   })
 
-  const { sendMessage, isStreaming, cancelStream } = useStreamingChat()
+  const { sendMessage, regenerate, editAndResend, isStreaming, cancelStream } = useStreamingChat()
 
   const bottomRef = useRef<HTMLDivElement>(null)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
@@ -60,15 +61,11 @@ export function ChatView({
     }
   }, [activeChat?.messages.length, activeChat?.messages[activeChat.messages.length - 1]?.content, isAtBottom])
 
-  function handleSend(content: string) {
+  function handleSend(content: string, imageUrl?: string) {
     const apiKey = (() => {
       const stored = localStorage.getItem('jamba-settings')
       if (stored) {
-        try {
-          return JSON.parse(stored).state?.apiKey ?? ''
-        } catch {
-          return ''
-        }
+        try { return JSON.parse(stored).state?.apiKey ?? '' } catch { return '' }
       }
       return ''
     })()
@@ -82,15 +79,27 @@ export function ChatView({
     if (!chatId) {
       chatId = createChat(defaultModelId)
     }
-    sendMessage(chatId, content)
+    sendMessage(chatId, content, imageUrl)
   }
 
-  // Empty state — no active chat
+  function handleRegenerate() {
+    if (activeChatId) regenerate(activeChatId)
+  }
+
+  function handleEdit(messageId: string, newContent: string) {
+    if (activeChatId) editAndResend(activeChatId, messageId, newContent)
+  }
+
+  function handleBranch(messageId: string) {
+    if (activeChatId) branchChat(activeChatId, messageId)
+  }
+
+  // Empty state
   if (!activeChat) {
     return (
       <div className="flex-1 flex flex-col items-center justify-center gap-6 p-8 app-bg">
         <div className="text-center">
-          <h1 className="text-3xl font-bold mb-2 accent-text">Jamba</h1>
+          <h1 className="text-3xl font-bold mb-2 accent-text">OpenStarChat</h1>
           <p className="text-muted text-sm">Your OpenRouter chat interface</p>
         </div>
         <div className="flex flex-wrap gap-3 justify-center">
@@ -127,6 +136,8 @@ export function ChatView({
     )
   }
 
+  const visibleMessages = activeChat.messages.filter((m) => m.role !== 'system')
+
   return (
     <div className="flex-1 flex flex-col min-h-0 app-bg">
       {/* Chat header */}
@@ -136,10 +147,7 @@ export function ChatView({
       >
         <div className="flex items-center gap-2 min-w-0">
           {character && (
-            <span
-              className="text-lg"
-              title={character.name}
-            >
+            <span className="text-lg" title={character.name}>
               {character.emoji}
             </span>
           )}
@@ -171,11 +179,19 @@ export function ChatView({
         onScroll={handleScroll}
         className="flex-1 overflow-y-auto min-h-0 py-2"
       >
-        {activeChat.messages
-          .filter((m) => m.role !== 'system')
-          .map((msg) => (
-            <Message key={msg.id} message={msg} />
-          ))}
+        {visibleMessages.map((msg, idx) => (
+          <Message
+            key={msg.id}
+            message={msg}
+            chatId={activeChat.id}
+            isLast={idx === visibleMessages.length - 1}
+            isStreaming={isStreaming}
+            onBookmark={(msgId) => toggleBookmarkMessage(activeChat.id, msgId)}
+            onEdit={handleEdit}
+            onRegenerate={handleRegenerate}
+            onBranch={handleBranch}
+          />
+        ))}
         <div ref={bottomRef} />
       </div>
 

--- a/src/components/chat/Message.tsx
+++ b/src/components/chat/Message.tsx
@@ -3,12 +3,19 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
-import { Copy, Check } from 'lucide-react'
+import { Copy, Check, Bookmark, BookmarkCheck, Edit2, RefreshCw, GitBranch, X } from 'lucide-react'
 import clsx from 'clsx'
 import type { Message as MessageType } from '../../types'
 
 interface MessageProps {
   message: MessageType
+  chatId: string
+  isLast?: boolean
+  isStreaming?: boolean
+  onBookmark: (messageId: string) => void
+  onEdit: (messageId: string, newContent: string) => void
+  onRegenerate: () => void
+  onBranch: (messageId: string) => void
 }
 
 function CopyButton({ text }: { text: string }) {
@@ -29,8 +36,37 @@ function CopyButton({ text }: { text: string }) {
   )
 }
 
-export function Message({ message }: MessageProps) {
+function estimateCost(tokenCount: number): string | null {
+  if (!tokenCount) return null
+  return `~${tokenCount} tokens`
+}
+
+export function Message({
+  message,
+  chatId: _chatId,
+  isLast,
+  isStreaming,
+  onBookmark,
+  onEdit,
+  onRegenerate,
+  onBranch,
+}: MessageProps) {
   const isUser = message.role === 'user'
+  const [editing, setEditing] = useState(false)
+  const [editDraft, setEditDraft] = useState(message.content)
+
+  function submitEdit() {
+    const trimmed = editDraft.trim()
+    if (trimmed && trimmed !== message.content) {
+      onEdit(message.id, trimmed)
+    }
+    setEditing(false)
+  }
+
+  function cancelEdit() {
+    setEditDraft(message.content)
+    setEditing(false)
+  }
 
   return (
     <div
@@ -43,7 +79,6 @@ export function Message({ message }: MessageProps) {
       <div
         className={clsx(
           'shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold mt-0.5',
-          isUser ? 'bg-accent' : 'bg-surface'
         )}
         style={
           isUser
@@ -57,15 +92,44 @@ export function Message({ message }: MessageProps) {
       {/* Bubble */}
       <div className={clsx('flex flex-col gap-1 max-w-[80%]', isUser ? 'items-end' : 'items-start')}>
         <div
-          className={clsx(
-            'rounded-2xl px-4 py-2.5 text-sm leading-relaxed relative',
-            isUser ? 'user-bubble rounded-tr-sm' : 'surface rounded-tl-sm'
-          )}
+          className="rounded-2xl px-4 py-2.5 text-sm leading-relaxed relative"
           style={{
             background: isUser ? 'var(--user-bubble)' : 'var(--surface)',
+            borderRadius: isUser ? '1rem 0.25rem 1rem 1rem' : '0.25rem 1rem 1rem 1rem',
           }}
         >
-          {isUser ? (
+          {/* Attached image */}
+          {message.imageUrl && (
+            <img
+              src={message.imageUrl}
+              alt="Attached"
+              className="max-w-xs max-h-48 rounded-lg mb-2 object-contain"
+            />
+          )}
+
+          {editing && isUser ? (
+            <div className="flex flex-col gap-2">
+              <textarea
+                value={editDraft}
+                onChange={(e) => setEditDraft(e.target.value)}
+                className="bg-transparent outline-none resize-none text-sm leading-relaxed w-full min-h-[3rem]"
+                style={{ color: 'var(--text-primary)' }}
+                autoFocus
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); submitEdit() }
+                  if (e.key === 'Escape') cancelEdit()
+                }}
+              />
+              <div className="flex gap-1.5 justify-end">
+                <button onClick={cancelEdit} className="btn-ghost text-xs px-2 py-0.5 flex items-center gap-1">
+                  <X size={11} /> Cancel
+                </button>
+                <button onClick={submitEdit} className="btn-primary text-xs px-2 py-0.5">
+                  Send
+                </button>
+              </div>
+            </div>
+          ) : isUser ? (
             <p className="whitespace-pre-wrap break-words">{message.content}</p>
           ) : (
             <div
@@ -127,13 +191,7 @@ export function Message({ message }: MessageProps) {
                   table({ children }) {
                     return (
                       <div style={{ overflowX: 'auto' }}>
-                        <table
-                          style={{
-                            borderCollapse: 'collapse',
-                            width: '100%',
-                            fontSize: '0.85rem',
-                          }}
-                        >
+                        <table style={{ borderCollapse: 'collapse', width: '100%', fontSize: '0.85rem' }}>
                           {children}
                         </table>
                       </div>
@@ -141,27 +199,14 @@ export function Message({ message }: MessageProps) {
                   },
                   th({ children }) {
                     return (
-                      <th
-                        style={{
-                          borderBottom: '1px solid var(--border)',
-                          padding: '0.4rem 0.75rem',
-                          textAlign: 'left',
-                          color: 'var(--text-secondary)',
-                          fontWeight: 600,
-                        }}
-                      >
+                      <th style={{ borderBottom: '1px solid var(--border)', padding: '0.4rem 0.75rem', textAlign: 'left', color: 'var(--text-secondary)', fontWeight: 600 }}>
                         {children}
                       </th>
                     )
                   },
                   td({ children }) {
                     return (
-                      <td
-                        style={{
-                          borderBottom: '1px solid var(--border)',
-                          padding: '0.4rem 0.75rem',
-                        }}
-                      >
+                      <td style={{ borderBottom: '1px solid var(--border)', padding: '0.4rem 0.75rem' }}>
                         {children}
                       </td>
                     )
@@ -176,8 +221,56 @@ export function Message({ message }: MessageProps) {
             </div>
           )}
         </div>
-        <div className={clsx('flex gap-1', isUser ? 'flex-row-reverse' : 'flex-row')}>
+
+        {/* Action row */}
+        <div className={clsx('flex items-center gap-0.5', isUser ? 'flex-row-reverse' : 'flex-row')}>
           <CopyButton text={message.content} />
+
+          <button
+            onClick={() => onBookmark(message.id)}
+            className={clsx(
+              'p-1 rounded transition-opacity btn-ghost',
+              message.bookmarked ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+            )}
+            style={message.bookmarked ? { color: 'var(--accent)' } : undefined}
+            title={message.bookmarked ? 'Remove bookmark' : 'Bookmark'}
+          >
+            {message.bookmarked ? <BookmarkCheck size={13} /> : <Bookmark size={13} />}
+          </button>
+
+          {isUser && !isStreaming && (
+            <button
+              onClick={() => { setEditDraft(message.content); setEditing(true) }}
+              className="p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity btn-ghost"
+              title="Edit message"
+            >
+              <Edit2 size={13} />
+            </button>
+          )}
+
+          {!isUser && isLast && !isStreaming && (
+            <button
+              onClick={onRegenerate}
+              className="p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity btn-ghost"
+              title="Regenerate response"
+            >
+              <RefreshCw size={13} />
+            </button>
+          )}
+
+          <button
+            onClick={() => onBranch(message.id)}
+            className="p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity btn-ghost"
+            title="Branch from here"
+          >
+            <GitBranch size={13} />
+          </button>
+
+          {message.tokenCount != null && (
+            <span className="text-xs opacity-0 group-hover:opacity-100 transition-opacity" style={{ color: 'var(--text-secondary)' }}>
+              {estimateCost(message.tokenCount)}
+            </span>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -4,9 +4,10 @@ import { Sidebar } from './Sidebar'
 interface AppLayoutProps {
   children: React.ReactNode
   onOpenSettings: () => void
+  onOpenBookmarks: () => void
 }
 
-export function AppLayout({ children, onOpenSettings }: AppLayoutProps) {
+export function AppLayout({ children, onOpenSettings, onOpenBookmarks }: AppLayoutProps) {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
 
   return (
@@ -15,6 +16,7 @@ export function AppLayout({ children, onOpenSettings }: AppLayoutProps) {
         collapsed={sidebarCollapsed}
         onToggle={() => setSidebarCollapsed((v) => !v)}
         onOpenSettings={onOpenSettings}
+        onOpenBookmarks={onOpenBookmarks}
       />
       <main className="flex-1 flex flex-col min-w-0 overflow-hidden">
         {children}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,25 +1,37 @@
-import { useState } from 'react'
-import { MessageSquare, Plus, Trash2, Download, Settings, ChevronLeft, ChevronRight } from 'lucide-react'
+import { useState, useRef } from 'react'
+import {
+  MessageSquare, Plus, Trash2, Settings, ChevronLeft, ChevronRight,
+  Download, Upload, Pin, PinOff, Search, Bookmark, ChevronDown,
+} from 'lucide-react'
 import { useChatStore } from '../../store/chatStore'
 import { useSettingsStore } from '../../store/settingsStore'
 import clsx from 'clsx'
+import type { Chat } from '../../types'
 
 interface SidebarProps {
   collapsed: boolean
   onToggle: () => void
   onOpenSettings: () => void
+  onOpenBookmarks: () => void
 }
 
-export function Sidebar({ collapsed, onToggle, onOpenSettings }: SidebarProps) {
+export function Sidebar({ collapsed, onToggle, onOpenSettings, onOpenBookmarks }: SidebarProps) {
   const chats = useChatStore((s) => s.chats)
   const activeChatId = useChatStore((s) => s.activeChatId)
   const createChat = useChatStore((s) => s.createChat)
   const deleteChat = useChatStore((s) => s.deleteChat)
   const setActiveChatId = useChatStore((s) => s.setActiveChatId)
   const exportChats = useChatStore((s) => s.exportChats)
+  const exportChatsMarkdown = useChatStore((s) => s.exportChatsMarkdown)
+  const exportChatsText = useChatStore((s) => s.exportChatsText)
+  const importChats = useChatStore((s) => s.importChats)
+  const togglePinChat = useChatStore((s) => s.togglePinChat)
   const defaultModelId = useSettingsStore((s) => s.defaultModelId)
 
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [showExportMenu, setShowExportMenu] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   function handleNewChat() {
     createChat(defaultModelId)
@@ -36,7 +48,87 @@ export function Sidebar({ collapsed, onToggle, onOpenSettings }: SidebarProps) {
     }
   }
 
-  const sorted = [...chats].sort((a, b) => b.updatedAt - a.updatedAt)
+  function handlePinChat(id: string, e: React.MouseEvent) {
+    e.stopPropagation()
+    togglePinChat(id)
+  }
+
+  function handleImport(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = () => {
+      try {
+        const data = JSON.parse(reader.result as string)
+        if (Array.isArray(data)) {
+          importChats(data as Chat[])
+        }
+      } catch {
+        // invalid JSON — ignore
+      }
+    }
+    reader.readAsText(file)
+    e.target.value = ''
+  }
+
+  const q = searchQuery.toLowerCase().trim()
+  const filtered = chats.filter((c) => {
+    if (!q) return true
+    if (c.title.toLowerCase().includes(q)) return true
+    return c.messages.some((m) => m.content.toLowerCase().includes(q))
+  })
+
+  const pinned = filtered.filter((c) => c.pinned).sort((a, b) => b.updatedAt - a.updatedAt)
+  const unpinned = filtered.filter((c) => !c.pinned).sort((a, b) => b.updatedAt - a.updatedAt)
+  const sorted = [...pinned, ...unpinned]
+
+  function ChatRow({ chat }: { chat: Chat }) {
+    const isActive = activeChatId === chat.id
+    return (
+      <button
+        key={chat.id}
+        onClick={() => setActiveChatId(chat.id)}
+        className={clsx(
+          'w-full flex items-center gap-2 px-2 py-2 mx-0 rounded-md text-left text-sm group transition-colors relative',
+          isActive ? 'bg-accent text-white' : 'hover:bg-tertiary'
+        )}
+        style={isActive ? { background: 'var(--accent)', color: 'white' } : undefined}
+        title={collapsed ? chat.title : undefined}
+      >
+        {chat.pinned ? (
+          <Pin size={13} className="shrink-0" style={{ color: isActive ? 'white' : 'var(--accent)' }} />
+        ) : (
+          <MessageSquare size={14} className="shrink-0" style={{ color: isActive ? 'white' : 'var(--text-secondary)' }} />
+        )}
+        {!collapsed && (
+          <>
+            <span className="truncate flex-1 min-w-0">{chat.title}</span>
+            <div className="shrink-0 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+              <button
+                onClick={(e) => handlePinChat(chat.id, e)}
+                className="p-0.5 rounded"
+                style={{ color: chat.pinned ? 'var(--accent)' : undefined }}
+                title={chat.pinned ? 'Unpin' : 'Pin'}
+              >
+                {chat.pinned ? <PinOff size={11} /> : <Pin size={11} />}
+              </button>
+              <button
+                onClick={(e) => handleDeleteChat(chat.id, e)}
+                className={clsx(
+                  'p-0.5 rounded',
+                  deleteConfirmId === chat.id ? 'opacity-100' : ''
+                )}
+                style={{ color: deleteConfirmId === chat.id ? 'var(--danger)' : undefined }}
+                title={deleteConfirmId === chat.id ? 'Click again to confirm' : 'Delete chat'}
+              >
+                <Trash2 size={11} />
+              </button>
+            </div>
+          </>
+        )}
+      </button>
+    )
+  }
 
   return (
     <aside
@@ -49,7 +141,7 @@ export function Sidebar({ collapsed, onToggle, onOpenSettings }: SidebarProps) {
       {/* Header */}
       <div className="flex items-center justify-between p-3 border-b border-subtle shrink-0">
         {!collapsed && (
-          <span className="font-bold text-lg tracking-tight accent-text">Jamba</span>
+          <span className="font-bold text-lg tracking-tight accent-text">OpenStarChat</span>
         )}
         <button
           onClick={onToggle}
@@ -60,7 +152,7 @@ export function Sidebar({ collapsed, onToggle, onOpenSettings }: SidebarProps) {
         </button>
       </div>
 
-      {/* New Chat button */}
+      {/* New Chat */}
       <div className="p-2 shrink-0">
         <button
           onClick={handleNewChat}
@@ -68,81 +160,115 @@ export function Sidebar({ collapsed, onToggle, onOpenSettings }: SidebarProps) {
             'btn-primary flex items-center gap-2 w-full justify-center text-sm',
             collapsed ? 'p-2' : 'px-3 py-2'
           )}
-          title="New Chat"
+          title="New Chat (Ctrl+N)"
         >
           <Plus size={16} />
           {!collapsed && <span>New Chat</span>}
         </button>
       </div>
 
+      {/* Search */}
+      {!collapsed && (
+        <div className="px-2 pb-1 shrink-0">
+          <div
+            className="flex items-center gap-2 px-2.5 py-1.5 rounded-lg border border-subtle"
+            style={{ background: 'var(--bg-tertiary)' }}
+          >
+            <Search size={13} className="text-muted shrink-0" />
+            <input
+              type="text"
+              placeholder="Search chats…"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="bg-transparent outline-none text-xs flex-1 min-w-0"
+              style={{ color: 'var(--text-primary)' }}
+            />
+          </div>
+        </div>
+      )}
+
       {/* Chat list */}
-      <div className="flex-1 overflow-y-auto min-h-0 py-1">
+      <div className="flex-1 overflow-y-auto min-h-0 py-1 px-1">
         {sorted.length === 0 && !collapsed && (
-          <p className="text-center text-muted text-xs px-4 py-8">No chats yet. Start a new one!</p>
+          <p className="text-center text-muted text-xs px-4 py-8">
+            {searchQuery ? 'No matching chats.' : 'No chats yet. Start a new one!'}
+          </p>
         )}
         {sorted.map((chat) => (
-          <button
-            key={chat.id}
-            onClick={() => setActiveChatId(chat.id)}
-            className={clsx(
-              'w-full flex items-center gap-2 px-2 py-2 mx-0 rounded-md text-left text-sm group transition-colors relative',
-              activeChatId === chat.id
-                ? 'bg-accent text-white'
-                : 'hover:bg-tertiary'
-            )}
-            style={
-              activeChatId === chat.id
-                ? { background: 'var(--accent)', color: 'white' }
-                : undefined
-            }
-            title={collapsed ? chat.title : undefined}
-          >
-            <MessageSquare
-              size={14}
-              className="shrink-0"
-              style={activeChatId === chat.id ? { color: 'white' } : { color: 'var(--text-secondary)' }}
-            />
-            {!collapsed && (
-              <>
-                <span className="truncate flex-1 min-w-0">{chat.title}</span>
-                <button
-                  onClick={(e) => handleDeleteChat(chat.id, e)}
-                  className={clsx(
-                    'shrink-0 p-0.5 rounded opacity-0 group-hover:opacity-100 transition-opacity',
-                    deleteConfirmId === chat.id
-                      ? 'opacity-100 text-red-400'
-                      : 'hover:text-red-400'
-                  )}
-                  style={{ color: deleteConfirmId === chat.id ? 'var(--danger)' : undefined }}
-                  title={deleteConfirmId === chat.id ? 'Click again to confirm' : 'Delete chat'}
-                >
-                  <Trash2 size={13} />
-                </button>
-              </>
-            )}
-          </button>
+          <ChatRow key={chat.id} chat={chat} />
         ))}
       </div>
 
-      {/* Footer actions */}
+      {/* Footer */}
       <div className="border-t border-subtle p-2 shrink-0 flex flex-col gap-1">
+        {/* Bookmarks */}
         <button
-          onClick={exportChats}
-          className={clsx(
-            'btn-ghost flex items-center gap-2 w-full text-sm',
-            collapsed ? 'justify-center' : ''
-          )}
-          title="Export chats as JSON"
+          onClick={onOpenBookmarks}
+          className={clsx('btn-ghost flex items-center gap-2 w-full text-sm', collapsed ? 'justify-center' : '')}
+          title="Bookmarked messages"
         >
-          <Download size={15} />
-          {!collapsed && <span>Export Chats</span>}
+          <Bookmark size={15} />
+          {!collapsed && <span>Bookmarks</span>}
         </button>
+
+        {/* Export with submenu */}
+        <div className="relative">
+          <button
+            onClick={() => setShowExportMenu((v) => !v)}
+            className={clsx('btn-ghost flex items-center gap-2 w-full text-sm', collapsed ? 'justify-center' : '')}
+            title="Export chats"
+          >
+            <Download size={15} />
+            {!collapsed && (
+              <>
+                <span className="flex-1 text-left">Export Chats</span>
+                <ChevronDown size={12} className={clsx('transition-transform', showExportMenu && 'rotate-180')} />
+              </>
+            )}
+          </button>
+          {showExportMenu && !collapsed && (
+            <div
+              className="absolute bottom-full left-0 mb-1 w-full rounded-lg border border-subtle shadow-lg overflow-hidden z-10"
+              style={{ background: 'var(--bg-secondary)' }}
+            >
+              {[
+                { label: 'JSON', fn: exportChats },
+                { label: 'Markdown', fn: exportChatsMarkdown },
+                { label: 'Plain Text', fn: exportChatsText },
+              ].map(({ label, fn }) => (
+                <button
+                  key={label}
+                  onClick={() => { fn(); setShowExportMenu(false) }}
+                  className="w-full text-left px-3 py-2 text-xs btn-ghost rounded-none"
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Import */}
+        <button
+          onClick={() => fileInputRef.current?.click()}
+          className={clsx('btn-ghost flex items-center gap-2 w-full text-sm', collapsed ? 'justify-center' : '')}
+          title="Import chats from JSON"
+        >
+          <Upload size={15} />
+          {!collapsed && <span>Import Chats</span>}
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="application/json,.json"
+          className="hidden"
+          onChange={handleImport}
+        />
+
+        {/* Settings */}
         <button
           onClick={onOpenSettings}
-          className={clsx(
-            'btn-ghost flex items-center gap-2 w-full text-sm',
-            collapsed ? 'justify-center' : ''
-          )}
+          className={clsx('btn-ghost flex items-center gap-2 w-full text-sm', collapsed ? 'justify-center' : '')}
           title="Settings"
         >
           <Settings size={15} />

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react'
-import { X, Eye, EyeOff, Check, AlertCircle, Loader, KeyRound } from 'lucide-react'
+import { X, Eye, EyeOff, Check, AlertCircle, Loader, KeyRound, Palette } from 'lucide-react'
 import { useSettingsStore } from '../../store/settingsStore'
 import { fetchModels } from '../../api/openrouter'
 import { THEME_SWATCHES } from '../../types'
-import type { ThemeName } from '../../types'
+import type { ThemeName, IdleAnimation, CustomThemeVars } from '../../types'
 import clsx from 'clsx'
 
 interface SettingsModalProps {
@@ -27,13 +27,8 @@ function ApiKeyField({ label, helper, value, onSave, placeholder }: ApiKeyFieldP
   const [message, setMessage] = useState('')
 
   async function handleTest() {
-    if (!draft.trim()) {
-      setMessage('Enter a key first.')
-      setStatus('error')
-      return
-    }
-    setStatus('loading')
-    setMessage('')
+    if (!draft.trim()) { setMessage('Enter a key first.'); setStatus('error'); return }
+    setStatus('loading'); setMessage('')
     try {
       const models = await fetchModels(draft.trim())
       setStatus('ok')
@@ -42,10 +37,6 @@ function ApiKeyField({ label, helper, value, onSave, placeholder }: ApiKeyFieldP
       setStatus('error')
       setMessage((e as Error).message)
     }
-  }
-
-  function handleSave() {
-    onSave(draft.trim())
   }
 
   return (
@@ -66,57 +57,61 @@ function ApiKeyField({ label, helper, value, onSave, placeholder }: ApiKeyFieldP
             placeholder={placeholder ?? 'sk-or-v1-…'}
             className="flex-1 bg-transparent outline-none px-3 py-2 text-sm font-mono"
             style={{ color: 'var(--text-primary)' }}
-            onKeyDown={(e) => e.key === 'Enter' && handleSave()}
+            onKeyDown={(e) => e.key === 'Enter' && onSave(draft.trim())}
           />
-          <button
-            onClick={() => setShow((v) => !v)}
-            className="px-2 py-2 btn-ghost"
-            title={show ? 'Hide key' : 'Show key'}
-          >
+          <button onClick={() => setShow((v) => !v)} className="px-2 py-2 btn-ghost" title={show ? 'Hide' : 'Show'}>
             {show ? <EyeOff size={14} /> : <Eye size={14} />}
           </button>
         </div>
-        <button onClick={handleSave} className="btn-primary text-sm px-3">
-          Save
-        </button>
+        <button onClick={() => onSave(draft.trim())} className="btn-primary text-sm px-3">Save</button>
       </div>
-
       <div className="flex items-center gap-2">
         <button
           onClick={handleTest}
           disabled={status === 'loading'}
           className="flex items-center gap-1.5 text-xs btn-ghost border border-subtle px-3 py-1.5 rounded-lg"
         >
-          {status === 'loading' ? (
-            <Loader size={12} className="animate-spin" />
-          ) : (
-            <span>Test Connection</span>
-          )}
+          {status === 'loading' ? <Loader size={12} className="animate-spin" /> : <span>Test Connection</span>}
         </button>
-        {status === 'ok' && (
-          <span className="flex items-center gap-1 text-xs" style={{ color: '#22c55e' }}>
-            <Check size={12} /> {message}
-          </span>
-        )}
-        {status === 'error' && (
-          <span className="flex items-center gap-1 text-xs" style={{ color: 'var(--danger)' }}>
-            <AlertCircle size={12} /> {message}
-          </span>
-        )}
+        {status === 'ok' && <span className="flex items-center gap-1 text-xs" style={{ color: '#22c55e' }}><Check size={12} /> {message}</span>}
+        {status === 'error' && <span className="flex items-center gap-1 text-xs" style={{ color: 'var(--danger)' }}><AlertCircle size={12} /> {message}</span>}
       </div>
-
       <div className="text-xs text-muted mt-2">{helper}</div>
     </section>
   )
 }
 
+const THEME_CUSTOM_FIELDS: { key: keyof CustomThemeVars; label: string }[] = [
+  { key: 'bgPrimary', label: 'Background' },
+  { key: 'bgSecondary', label: 'Sidebar / panels' },
+  { key: 'bgTertiary', label: 'Input / tertiary' },
+  { key: 'textPrimary', label: 'Primary text' },
+  { key: 'textSecondary', label: 'Secondary text' },
+  { key: 'accent', label: 'Accent color' },
+  { key: 'border', label: 'Border color' },
+  { key: 'surface', label: 'Message surface' },
+  { key: 'userBubble', label: 'User bubble' },
+  { key: 'danger', label: 'Danger / red' },
+]
+
+const IDLE_OPTIONS: { value: IdleAnimation; label: string }[] = [
+  { value: 'random', label: '🎲 Random' },
+  { value: 'starfield', label: '✨ Starfield' },
+  { value: 'shooting', label: '🌠 Shooting Stars' },
+  { value: 'aurora', label: '🌌 Aurora' },
+]
+
 export function SettingsModal({ onClose }: SettingsModalProps) {
   const apiKey = useSettingsStore((s) => s.apiKey)
   const builderApiKey = useSettingsStore((s) => s.builderApiKey)
   const theme = useSettingsStore((s) => s.theme)
+  const idleAnimation = useSettingsStore((s) => s.idleAnimation)
+  const customThemeVars = useSettingsStore((s) => s.customThemeVars)
   const setApiKey = useSettingsStore((s) => s.setApiKey)
   const setBuilderApiKey = useSettingsStore((s) => s.setBuilderApiKey)
   const setTheme = useSettingsStore((s) => s.setTheme)
+  const setIdleAnimation = useSettingsStore((s) => s.setIdleAnimation)
+  const setCustomThemeVars = useSettingsStore((s) => s.setCustomThemeVars)
 
   return (
     <div
@@ -131,9 +126,7 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-subtle shrink-0">
           <h2 className="font-bold text-base">⚙️ Settings</h2>
-          <button onClick={onClose} className="btn-ghost p-1.5 rounded-lg">
-            <X size={16} />
-          </button>
+          <button onClick={onClose} className="btn-ghost p-1.5 rounded-lg"><X size={16} /></button>
         </div>
 
         <div className="p-5 flex flex-col gap-6 overflow-y-auto">
@@ -141,39 +134,93 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
             label="OpenRouter API Key"
             value={apiKey}
             onSave={setApiKey}
-            helper={
-              <>
-                Get your key at <span className="accent-text">openrouter.ai/keys</span>.
-                Stored locally in your browser only.
-              </>
-            }
+            helper={<>Get your key at <span className="accent-text">openrouter.ai/keys</span>. Stored locally in your browser only.</>}
           />
 
           <ApiKeyField
             label="Builder API Key (optional)"
             value={builderApiKey}
             onSave={setBuilderApiKey}
-            helper={
-              <>
-                If set, AI Character Builder and Punch Up use this key.
-                Leave blank to fall back to your main key.
-              </>
-            }
+            helper={<>If set, AI Character Builder uses this key. Leave blank to fall back to your main key.</>}
           />
 
-          {/* Theme section */}
+          {/* Theme */}
           <section>
             <h3 className="font-semibold text-sm mb-3">Theme</h3>
             <div className="grid grid-cols-4 gap-2">
               {THEME_SWATCHES.map((s) => (
-                <ThemeSwatch
-                  key={s.name}
-                  swatch={s}
-                  active={theme === s.name}
-                  onSelect={(t) => setTheme(t)}
-                />
+                <ThemeSwatchBtn key={s.name} swatch={s} active={theme === s.name} onSelect={setTheme} />
+              ))}
+              {/* Custom theme swatch */}
+              <button
+                onClick={() => setTheme('custom')}
+                className={clsx(
+                  'relative rounded-xl overflow-hidden border-2 transition-all aspect-square flex flex-col',
+                  theme === 'custom' ? 'scale-105' : 'border-transparent hover:scale-105'
+                )}
+                style={{ borderColor: theme === 'custom' ? customThemeVars.accent : 'transparent' }}
+                title="Custom"
+              >
+                <div className="flex-1 flex">
+                  <div className="flex-1" style={{ background: customThemeVars.bgPrimary }} />
+                  <div className="flex-1" style={{ background: customThemeVars.bgSecondary }} />
+                </div>
+                <div className="h-4" style={{ background: customThemeVars.accent }} />
+                <span className="absolute inset-0 flex items-center justify-center text-xs font-semibold" style={{ color: '#ffffff', textShadow: '0 1px 3px rgba(0,0,0,0.8)' }}>
+                  Custom
+                </span>
+                {theme === 'custom' && (
+                  <span className="absolute top-1 right-1 w-4 h-4 rounded-full flex items-center justify-center" style={{ background: customThemeVars.accent }}>
+                    <Check size={10} color="white" />
+                  </span>
+                )}
+              </button>
+            </div>
+          </section>
+
+          {/* Custom theme editor */}
+          {theme === 'custom' && (
+            <section>
+              <h3 className="font-semibold text-sm mb-3 flex items-center gap-2">
+                <Palette size={13} /> Custom Theme Colors
+              </h3>
+              <div className="grid grid-cols-1 gap-2">
+                {THEME_CUSTOM_FIELDS.map(({ key, label }) => (
+                  <div key={key} className="flex items-center gap-3">
+                    <input
+                      type="color"
+                      value={customThemeVars[key]}
+                      onChange={(e) => setCustomThemeVars({ [key]: e.target.value })}
+                      className="w-8 h-8 rounded cursor-pointer border-0 p-0"
+                      style={{ background: 'none' }}
+                    />
+                    <span className="text-xs flex-1" style={{ color: 'var(--text-secondary)' }}>{label}</span>
+                    <span className="text-xs font-mono" style={{ color: 'var(--text-secondary)' }}>{customThemeVars[key]}</span>
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Idle Animation */}
+          <section>
+            <h3 className="font-semibold text-sm mb-3">Idle Animation</h3>
+            <div className="flex flex-wrap gap-2">
+              {IDLE_OPTIONS.map(({ value, label }) => (
+                <button
+                  key={value}
+                  onClick={() => setIdleAnimation(value)}
+                  className={clsx(
+                    'text-xs px-3 py-1.5 rounded-lg border transition-all',
+                    idleAnimation === value ? 'border-accent accent-text' : 'border-subtle btn-ghost'
+                  )}
+                  style={idleAnimation === value ? { borderColor: 'var(--accent)' } : undefined}
+                >
+                  {label}
+                </button>
               ))}
             </div>
+            <p className="text-xs text-muted mt-2">Appears after 15 seconds of inactivity. Click to dismiss.</p>
           </section>
         </div>
       </div>
@@ -181,7 +228,7 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
   )
 }
 
-function ThemeSwatch({
+function ThemeSwatchBtn({
   swatch,
   active,
   onSelect,
@@ -209,10 +256,7 @@ function ThemeSwatch({
         {swatch.label}
       </span>
       {active && (
-        <span
-          className="absolute top-1 right-1 w-4 h-4 rounded-full flex items-center justify-center"
-          style={{ background: swatch.accent }}
-        >
+        <span className="absolute top-1 right-1 w-4 h-4 rounded-full flex items-center justify-center" style={{ background: swatch.accent }}>
           <Check size={10} color="white" />
         </span>
       )}

--- a/src/hooks/useStreamingChat.ts
+++ b/src/hooks/useStreamingChat.ts
@@ -10,6 +10,7 @@ export function useStreamingChat() {
   const addMessage = useChatStore((s) => s.addMessage)
   const updateMessage = useChatStore((s) => s.updateMessage)
   const finalizeMessage = useChatStore((s) => s.finalizeMessage)
+  const truncateMessagesAfter = useChatStore((s) => s.truncateMessagesAfter)
   const chats = useChatStore((s) => s.chats)
   const apiKey = useSettingsStore((s) => s.apiKey)
   const pushRecentModel = useSettingsStore((s) => s.pushRecentModel)
@@ -20,19 +21,12 @@ export function useStreamingChat() {
     setIsStreaming(false)
   }
 
-  function sendMessage(chatId: string, userContent: string) {
-    const chat = chats.find((c) => c.id === chatId)
-    if (!chat) return
-
-    pushRecentModel(chat.modelId)
-
-    // Cancel any in-progress stream
-    cancelRef.current?.()
-
-    // Add user message
-    addMessage(chatId, { role: 'user', content: userContent })
-
-    // Add placeholder assistant message
+  function _stream(
+    chatId: string,
+    historyMessages: Pick<Message, 'role' | 'content' | 'imageUrl'>[],
+    modelId: string,
+    systemPrompt: string | undefined
+  ) {
     const assistantMsg: Message = addMessage(chatId, {
       role: 'assistant',
       content: '',
@@ -41,25 +35,19 @@ export function useStreamingChat() {
 
     setIsStreaming(true)
 
-    // Build the messages array from chat history (excluding the new empty assistant msg)
-    const historyMessages = [
-      ...chat.messages,
-      { id: '', role: 'user' as const, content: userContent, createdAt: Date.now() },
-    ].map(({ role, content }) => ({ role, content }))
-
     let accumulated = ''
 
     const cancel = streamChat({
       apiKey,
-      modelId: chat.modelId,
+      modelId,
       messages: historyMessages,
-      systemPrompt: chat.systemPrompt || undefined,
+      systemPrompt,
       onDelta: (delta) => {
         accumulated += delta
         updateMessage(chatId, assistantMsg.id, accumulated)
       },
-      onDone: () => {
-        finalizeMessage(chatId, assistantMsg.id)
+      onDone: (tokenCount) => {
+        finalizeMessage(chatId, assistantMsg.id, tokenCount)
         setIsStreaming(false)
         cancelRef.current = null
       },
@@ -74,5 +62,79 @@ export function useStreamingChat() {
     cancelRef.current = cancel
   }
 
-  return { sendMessage, isStreaming, cancelStream }
+  function sendMessage(chatId: string, userContent: string, imageUrl?: string) {
+    const chat = chats.find((c) => c.id === chatId)
+    if (!chat) return
+
+    pushRecentModel(chat.modelId)
+    cancelRef.current?.()
+
+    addMessage(chatId, { role: 'user', content: userContent, imageUrl })
+
+    const historyMessages: Pick<Message, 'role' | 'content' | 'imageUrl'>[] = [
+      ...chat.messages.map(({ role, content, imageUrl }) => ({ role, content, imageUrl })),
+      { role: 'user' as const, content: userContent, imageUrl },
+    ]
+
+    _stream(chatId, historyMessages, chat.modelId, chat.systemPrompt || undefined)
+  }
+
+  function regenerate(chatId: string) {
+    const chat = chats.find((c) => c.id === chatId)
+    if (!chat) return
+
+    // Find the last assistant message and remove it
+    const messages = [...chat.messages]
+    let lastAssistantIdx = -1
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === 'assistant') {
+        lastAssistantIdx = i
+        break
+      }
+    }
+    if (lastAssistantIdx === -1) return
+
+    const lastAssistantId = messages[lastAssistantIdx].id
+    truncateMessagesAfter(chatId, lastAssistantId)
+
+    // Build history up to (but not including) the removed assistant message
+    const historyMessages = messages
+      .slice(0, lastAssistantIdx)
+      .map(({ role, content, imageUrl }) => ({ role, content, imageUrl }))
+
+    cancelRef.current?.()
+    pushRecentModel(chat.modelId)
+    _stream(chatId, historyMessages, chat.modelId, chat.systemPrompt || undefined)
+  }
+
+  function editAndResend(chatId: string, messageId: string, newContent: string) {
+    const chat = chats.find((c) => c.id === chatId)
+    if (!chat) return
+
+    const idx = chat.messages.findIndex((m) => m.id === messageId)
+    if (idx === -1) return
+
+    // Truncate everything after this message (removes old response)
+    const nextMsg = chat.messages[idx + 1]
+    if (nextMsg) {
+      truncateMessagesAfter(chatId, nextMsg.id)
+    }
+
+    // Update the user message content
+    updateMessage(chatId, messageId, newContent)
+
+    // Build history up to and including this edited message
+    const historyMessages = [
+      ...chat.messages
+        .slice(0, idx)
+        .map(({ role, content, imageUrl }) => ({ role, content, imageUrl })),
+      { role: 'user' as const, content: newContent, imageUrl: chat.messages[idx].imageUrl },
+    ]
+
+    cancelRef.current?.()
+    pushRecentModel(chat.modelId)
+    _stream(chatId, historyMessages, chat.modelId, chat.systemPrompt || undefined)
+  }
+
+  return { sendMessage, regenerate, editAndResend, isStreaming, cancelStream }
 }

--- a/src/store/chatStore.ts
+++ b/src/store/chatStore.ts
@@ -21,8 +21,16 @@ interface ChatState {
   setActiveChatId: (id: string | null) => void
   addMessage: (chatId: string, message: Omit<Message, 'id' | 'createdAt'>) => Message
   updateMessage: (chatId: string, messageId: string, content: string) => void
-  finalizeMessage: (chatId: string, messageId: string) => void
+  finalizeMessage: (chatId: string, messageId: string, tokenCount?: number) => void
+  deleteMessage: (chatId: string, messageId: string) => void
+  toggleBookmarkMessage: (chatId: string, messageId: string) => void
+  truncateMessagesAfter: (chatId: string, messageId: string) => void
+  togglePinChat: (id: string) => void
+  branchChat: (chatId: string, upToMessageId: string) => string
   exportChats: () => void
+  exportChatsMarkdown: () => void
+  exportChatsText: () => void
+  importChats: (chats: Chat[]) => void
 
   // Prompt actions
   addPrompt: (p: Omit<Prompt, 'id'>) => void
@@ -54,6 +62,7 @@ export const useChatStore = create<ChatState>()(
           messages: [],
           createdAt: Date.now(),
           updatedAt: Date.now(),
+          pinned: false,
         }
         set((s) => ({ chats: [chat, ...s.chats], activeChatId: id }))
         return id
@@ -113,18 +122,96 @@ export const useChatStore = create<ChatState>()(
         }))
       },
 
-      finalizeMessage: (chatId, messageId) => {
+      finalizeMessage: (chatId, messageId, tokenCount) => {
         set((s) => ({
           chats: s.chats.map((c) => {
             if (c.id !== chatId) return c
             return {
               ...c,
               messages: c.messages.map((m) =>
-                m.id === messageId ? { ...m, isStreaming: false } : m
+                m.id === messageId
+                  ? { ...m, isStreaming: false, ...(tokenCount !== undefined ? { tokenCount } : {}) }
+                  : m
               ),
             }
           }),
         }))
+      },
+
+      deleteMessage: (chatId, messageId) => {
+        set((s) => ({
+          chats: s.chats.map((c) => {
+            if (c.id !== chatId) return c
+            return {
+              ...c,
+              messages: c.messages.filter((m) => m.id !== messageId),
+              updatedAt: Date.now(),
+            }
+          }),
+        }))
+      },
+
+      toggleBookmarkMessage: (chatId, messageId) => {
+        set((s) => ({
+          chats: s.chats.map((c) => {
+            if (c.id !== chatId) return c
+            return {
+              ...c,
+              messages: c.messages.map((m) =>
+                m.id === messageId ? { ...m, bookmarked: !m.bookmarked } : m
+              ),
+            }
+          }),
+        }))
+      },
+
+      truncateMessagesAfter: (chatId, messageId) => {
+        set((s) => ({
+          chats: s.chats.map((c) => {
+            if (c.id !== chatId) return c
+            const idx = c.messages.findIndex((m) => m.id === messageId)
+            if (idx === -1) return c
+            return {
+              ...c,
+              messages: c.messages.slice(0, idx),
+              updatedAt: Date.now(),
+            }
+          }),
+        }))
+      },
+
+      togglePinChat: (id) => {
+        set((s) => ({
+          chats: s.chats.map((c) =>
+            c.id === id ? { ...c, pinned: !c.pinned } : c
+          ),
+        }))
+      },
+
+      branchChat: (chatId, upToMessageId) => {
+        const { chats } = get()
+        const source = chats.find((c) => c.id === chatId)
+        if (!source) return chatId
+
+        const idx = source.messages.findIndex((m) => m.id === upToMessageId)
+        const messages = source.messages.slice(0, idx + 1).map((m) => ({
+          ...m,
+          id: nanoid(),
+          createdAt: Date.now(),
+        }))
+
+        const newId = nanoid()
+        const newChat: Chat = {
+          ...source,
+          id: newId,
+          title: `${source.title} (branch)`,
+          messages,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+          pinned: false,
+        }
+        set((s) => ({ chats: [newChat, ...s.chats], activeChatId: newId }))
+        return newId
       },
 
       exportChats: () => {
@@ -135,9 +222,66 @@ export const useChatStore = create<ChatState>()(
         const url = URL.createObjectURL(blob)
         const a = document.createElement('a')
         a.href = url
-        a.download = `jamba-chats-${new Date().toISOString().slice(0, 10)}.json`
+        a.download = `openstarchat-${new Date().toISOString().slice(0, 10)}.json`
         a.click()
         URL.revokeObjectURL(url)
+      },
+
+      exportChatsMarkdown: () => {
+        const { chats } = get()
+        const lines: string[] = []
+        for (const chat of chats) {
+          lines.push(`# ${chat.title}`)
+          lines.push(`*Model: ${chat.modelId} | ${new Date(chat.createdAt).toLocaleString()}*`)
+          lines.push('')
+          for (const msg of chat.messages) {
+            if (msg.role === 'system') continue
+            lines.push(`### ${msg.role === 'user' ? 'You' : 'AI'}`)
+            lines.push(msg.content)
+            lines.push('')
+          }
+          lines.push('---')
+          lines.push('')
+        }
+        const blob = new Blob([lines.join('\n')], { type: 'text/markdown' })
+        const url = URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        a.href = url
+        a.download = `openstarchat-${new Date().toISOString().slice(0, 10)}.md`
+        a.click()
+        URL.revokeObjectURL(url)
+      },
+
+      exportChatsText: () => {
+        const { chats } = get()
+        const lines: string[] = []
+        for (const chat of chats) {
+          lines.push(`=== ${chat.title} ===`)
+          lines.push(`Model: ${chat.modelId} | ${new Date(chat.createdAt).toLocaleString()}`)
+          lines.push('')
+          for (const msg of chat.messages) {
+            if (msg.role === 'system') continue
+            lines.push(`[${msg.role === 'user' ? 'You' : 'AI'}]`)
+            lines.push(msg.content)
+            lines.push('')
+          }
+          lines.push('')
+        }
+        const blob = new Blob([lines.join('\n')], { type: 'text/plain' })
+        const url = URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        a.href = url
+        a.download = `openstarchat-${new Date().toISOString().slice(0, 10)}.txt`
+        a.click()
+        URL.revokeObjectURL(url)
+      },
+
+      importChats: (incoming) => {
+        set((s) => {
+          const existingIds = new Set(s.chats.map((c) => c.id))
+          const newChats = incoming.filter((c) => !existingIds.has(c.id))
+          return { chats: [...newChats, ...s.chats] }
+        })
       },
 
       addPrompt: (p) => {
@@ -177,7 +321,6 @@ export const useChatStore = create<ChatState>()(
       partialize: (state) => ({
         chats: state.chats.map((c) => ({
           ...c,
-          // Clear streaming flag on persist
           messages: c.messages.map((m) => ({ ...m, isStreaming: false })),
         })),
         activeChatId: state.activeChatId,

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -1,8 +1,35 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import type { ThemeName } from '../types'
+import type { ThemeName, IdleAnimation, CustomThemeVars } from '../types'
+import { DEFAULT_CUSTOM_THEME } from '../types'
 
 const RECENT_CAP = 8
+
+function applyCustomTheme(vars: CustomThemeVars) {
+  const el = document.documentElement
+  el.style.setProperty('--bg-primary', vars.bgPrimary)
+  el.style.setProperty('--bg-secondary', vars.bgSecondary)
+  el.style.setProperty('--bg-tertiary', vars.bgTertiary)
+  el.style.setProperty('--text-primary', vars.textPrimary)
+  el.style.setProperty('--text-secondary', vars.textSecondary)
+  el.style.setProperty('--accent', vars.accent)
+  el.style.setProperty('--accent-hover', vars.accent)
+  el.style.setProperty('--border', vars.border)
+  el.style.setProperty('--surface', vars.surface)
+  el.style.setProperty('--user-bubble', vars.userBubble)
+  el.style.setProperty('--danger', vars.danger)
+  el.style.setProperty('--scrollbar', vars.border)
+}
+
+function clearCustomTheme() {
+  const el = document.documentElement
+  const props = [
+    '--bg-primary', '--bg-secondary', '--bg-tertiary',
+    '--text-primary', '--text-secondary', '--accent', '--accent-hover',
+    '--border', '--surface', '--user-bubble', '--danger', '--scrollbar',
+  ]
+  props.forEach((p) => el.style.removeProperty(p))
+}
 
 interface SettingsState {
   apiKey: string
@@ -11,6 +38,8 @@ interface SettingsState {
   defaultModelId: string
   favoriteModelIds: string[]
   recentModelIds: string[]
+  idleAnimation: IdleAnimation
+  customThemeVars: CustomThemeVars
   setApiKey: (key: string) => void
   setBuilderApiKey: (key: string) => void
   setTheme: (theme: ThemeName) => void
@@ -18,6 +47,8 @@ interface SettingsState {
   toggleFavoriteModel: (id: string) => void
   isFavoriteModel: (id: string) => boolean
   pushRecentModel: (id: string) => void
+  setIdleAnimation: (a: IdleAnimation) => void
+  setCustomThemeVars: (vars: Partial<CustomThemeVars>) => void
 }
 
 export const useSettingsStore = create<SettingsState>()(
@@ -29,27 +60,56 @@ export const useSettingsStore = create<SettingsState>()(
       defaultModelId: 'openai/gpt-4o-mini',
       favoriteModelIds: [],
       recentModelIds: [],
+      idleAnimation: 'random',
+      customThemeVars: DEFAULT_CUSTOM_THEME,
+
       setApiKey: (key) => set({ apiKey: key }),
       setBuilderApiKey: (key) => set({ builderApiKey: key }),
+
       setTheme: (theme) => {
         document.documentElement.setAttribute('data-theme', theme)
+        if (theme === 'custom') {
+          applyCustomTheme(get().customThemeVars)
+        } else {
+          clearCustomTheme()
+        }
         set({ theme })
       },
+
       setDefaultModelId: (id) => set({ defaultModelId: id }),
+
       toggleFavoriteModel: (id) =>
         set((s) => ({
           favoriteModelIds: s.favoriteModelIds.includes(id)
             ? s.favoriteModelIds.filter((m) => m !== id)
             : [...s.favoriteModelIds, id],
         })),
+
       isFavoriteModel: (id) => get().favoriteModelIds.includes(id),
+
       pushRecentModel: (id) =>
         set((s) => ({
           recentModelIds: [id, ...s.recentModelIds.filter((m) => m !== id)].slice(0, RECENT_CAP),
         })),
+
+      setIdleAnimation: (a) => set({ idleAnimation: a }),
+
+      setCustomThemeVars: (vars) => {
+        set((s) => {
+          const next = { ...s.customThemeVars, ...vars }
+          if (s.theme === 'custom') applyCustomTheme(next)
+          return { customThemeVars: next }
+        })
+      },
     }),
     {
       name: 'jamba-settings',
+      onRehydrateStorage: () => (state) => {
+        if (state?.theme === 'custom') {
+          document.documentElement.setAttribute('data-theme', 'custom')
+          applyCustomTheme(state.customThemeVars)
+        }
+      },
     }
   )
 )

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-export type ThemeName = 'dark' | 'amoled' | 'light' | 'dracula' | 'nord' | 'cyberpunk' | 'solarized'
+export type ThemeName = 'dark' | 'amoled' | 'light' | 'dracula' | 'nord' | 'cyberpunk' | 'solarized' | 'custom'
 
 export interface Model {
   id: string
@@ -11,14 +11,20 @@ export interface Model {
     completion: string
   }
   description?: string
+  architecture?: {
+    modality?: string
+  }
 }
 
 export interface Message {
   id: string
   role: 'user' | 'assistant' | 'system'
   content: string
+  imageUrl?: string
   createdAt: number
   isStreaming?: boolean
+  bookmarked?: boolean
+  tokenCount?: number
 }
 
 export interface Chat {
@@ -30,6 +36,7 @@ export interface Chat {
   messages: Message[]
   createdAt: number
   updatedAt: number
+  pinned?: boolean
 }
 
 export interface Character {
@@ -87,3 +94,31 @@ export const THEME_SWATCHES: ThemeSwatch[] = [
   { name: 'cyberpunk', label: 'Cyberpunk', bg: '#0d0d0d', accent: '#00ffff' },
   { name: 'solarized', label: 'Solarized', bg: '#002b36', accent: '#268bd2' },
 ]
+
+export type IdleAnimation = 'starfield' | 'shooting' | 'aurora' | 'random'
+
+export interface CustomThemeVars {
+  bgPrimary: string
+  bgSecondary: string
+  bgTertiary: string
+  textPrimary: string
+  textSecondary: string
+  accent: string
+  border: string
+  surface: string
+  userBubble: string
+  danger: string
+}
+
+export const DEFAULT_CUSTOM_THEME: CustomThemeVars = {
+  bgPrimary: '#1a1a2e',
+  bgSecondary: '#16213e',
+  bgTertiary: '#0f3460',
+  textPrimary: '#e0e0e0',
+  textSecondary: '#a0a0b0',
+  accent: '#e94560',
+  border: '#1a3a5c',
+  surface: '#0f3460',
+  userBubble: '#2d1b3d',
+  danger: '#ef4444',
+}


### PR DESCRIPTION
- Message editing & regeneration: edit any user message to resend, or regenerate the last AI response
- Image uploads: attach images to messages for multimodal-capable models (stored as base64 data URLs)
- Chat search: sidebar search bar filters by title and message content
- Pinned chats: pin important conversations to the top of the sidebar
- Bookmarked messages: star individual messages and view them in a dedicated panel
- Chat branching: fork any conversation at any message into a new chat
- Chat import: load previously exported JSON files back into the app
- More export formats: export chats as JSON, Markdown, or plain text
- Keyboard shortcuts: Ctrl+K model picker, Ctrl+N new chat, Ctrl+/ prompts, Ctrl+B bookmarks, Ctrl+, settings, Esc closes all
- Custom theme editor: pick "Custom" theme and tweak all CSS variables with color pickers
- Idle animation picker: choose starfield, shooting stars, aurora, or random in settings
- Token counter: approximate token count shown on hover for each AI message
- Stop generation was already implemented; multimodal API support added

https://claude.ai/code/session_01HF1h3MmuPLsvdz4UizQWvU