### PR TITLE
Add Characters tab: transcribe, build, and chat with personas

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,12 +4,15 @@ import { ChatView } from './components/chat/ChatView'
 import { ModelPicker } from './components/models/ModelPicker'
 import { PromptLibrary } from './components/prompts/PromptLibrary'
 import { CharacterSelector } from './components/characters/CharacterSelector'
+import { CharactersPage } from './components/characters/CharactersPage'
 import { SettingsModal } from './components/settings/SettingsModal'
 import { BookmarksPanel } from './components/bookmarks/BookmarksPanel'
 import { Starfield } from './components/Starfield'
 import { useIdleTimer } from './hooks/useIdleTimer'
 import { useChatStore } from './store/chatStore'
 import { useSettingsStore } from './store/settingsStore'
+
+type MainView = 'chat' | 'characters'
 
 export default function App() {
   const [showSettings, setShowSettings] = useState(false)
@@ -18,6 +21,7 @@ export default function App() {
   const [showCharacters, setShowCharacters] = useState(false)
   const [showBookmarks, setShowBookmarks] = useState(false)
   const [isIdle, setIsIdle] = useState(false)
+  const [view, setView] = useState<MainView>('chat')
 
   const activeChatId = useChatStore((s) => s.activeChatId)
   const createChat = useChatStore((s) => s.createChat)
@@ -35,7 +39,6 @@ export default function App() {
   useEffect(() => {
     function handleKey(e: KeyboardEvent) {
       const ctrl = e.ctrlKey || e.metaKey
-      // Don't fire when typing in an input/textarea
       const tag = (e.target as HTMLElement).tagName.toLowerCase()
       const isInput = tag === 'input' || tag === 'textarea'
 
@@ -55,6 +58,7 @@ export default function App() {
           setShowModelPicker((v) => !v)
         } else if (e.key === 'n' || e.key === 'N') {
           e.preventDefault()
+          setView('chat')
           if (apiKey) createChat(defaultModelId)
           else setShowSettings(true)
         } else if (e.key === '/') {
@@ -66,6 +70,9 @@ export default function App() {
         } else if (e.key === ',') {
           e.preventDefault()
           setShowSettings((v) => !v)
+        } else if ((e.key === 'p' || e.key === 'P') && e.shiftKey) {
+          e.preventDefault()
+          setView((v) => (v === 'characters' ? 'chat' : 'characters'))
         }
       }
     }
@@ -76,6 +83,7 @@ export default function App() {
 
   function handleNavigateToChat(chatId: string) {
     setActiveChatId(chatId)
+    setView('chat')
   }
 
   return (
@@ -83,13 +91,20 @@ export default function App() {
       <AppLayout
         onOpenSettings={() => setShowSettings(true)}
         onOpenBookmarks={() => setShowBookmarks(true)}
+        view={view}
+        onChangeView={setView}
       >
-        <ChatView
-          onOpenModelPicker={() => setShowModelPicker(true)}
-          onOpenPrompts={() => setShowPrompts(true)}
-          onOpenCharacters={() => setShowCharacters(true)}
-          onNeedApiKey={() => setShowSettings(true)}
-        />
+        {view === 'chat' ? (
+          <ChatView
+            onOpenModelPicker={() => setShowModelPicker(true)}
+            onOpenPrompts={() => setShowPrompts(true)}
+            onOpenCharacters={() => setShowCharacters(true)}
+            onOpenCharactersPage={() => setView('characters')}
+            onNeedApiKey={() => setShowSettings(true)}
+          />
+        ) : (
+          <CharactersPage onBackToChat={() => setView('chat')} />
+        )}
       </AppLayout>
 
       {/* Modals */}
@@ -98,7 +113,15 @@ export default function App() {
         <ModelPicker onClose={() => setShowModelPicker(false)} chatId={activeChatId} />
       )}
       {showPrompts && <PromptLibrary onClose={() => setShowPrompts(false)} />}
-      {showCharacters && <CharacterSelector onClose={() => setShowCharacters(false)} />}
+      {showCharacters && (
+        <CharacterSelector
+          onClose={() => setShowCharacters(false)}
+          onOpenManager={() => {
+            setShowCharacters(false)
+            setView('characters')
+          }}
+        />
+      )}
       {showBookmarks && (
         <BookmarksPanel
           onClose={() => setShowBookmarks(false)}

--- a/src/components/characters/CharacterEditor.tsx
+++ b/src/components/characters/CharacterEditor.tsx
@@ -1,0 +1,272 @@
+import { useRef, useState, useEffect } from 'react'
+import { Upload, X, Image as ImageIcon, Save, Trash2 } from 'lucide-react'
+import type { Character } from '../../types'
+
+const EMOJI_OPTIONS = ['🌸', '💻', '✍️', '🧙', '🃏', '🔮', '🦊', '🐉', '🌙', '⚡', '🎯', '🧪', '🤖', '👾', '🦋']
+const COLOR_OPTIONS = ['#bd93f9', '#50fa7b', '#ffb86c', '#8be9fd', '#ff79c6', '#ff5555', '#f1fa8c', '#268bd2', '#2aa198', '#859900']
+
+const MAX_AVATAR_BYTES = 1_500_000
+
+export type CharacterDraft = Omit<Character, 'id' | 'isBuiltIn'>
+
+interface CharacterEditorProps {
+  initial?: Partial<Character>
+  onSave: (draft: CharacterDraft) => void
+  onCancel?: () => void
+  onDelete?: () => void
+  saveLabel?: string
+  embedded?: boolean
+}
+
+export function CharacterEditor({
+  initial,
+  onSave,
+  onCancel,
+  onDelete,
+  saveLabel = 'Save Character',
+  embedded,
+}: CharacterEditorProps) {
+  const [name, setName] = useState(initial?.name ?? '')
+  const [emoji, setEmoji] = useState(initial?.emoji ?? '🤖')
+  const [color, setColor] = useState(initial?.color ?? '#bd93f9')
+  const [description, setDescription] = useState(initial?.description ?? '')
+  const [systemPrompt, setSystemPrompt] = useState(initial?.systemPrompt ?? '')
+  const [notes, setNotes] = useState(initial?.notes ?? '')
+  const [tagsText, setTagsText] = useState((initial?.tags ?? []).join(', '))
+  const [avatarUrl, setAvatarUrl] = useState<string | undefined>(initial?.avatarUrl)
+  const [avatarError, setAvatarError] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    setName(initial?.name ?? '')
+    setEmoji(initial?.emoji ?? '🤖')
+    setColor(initial?.color ?? '#bd93f9')
+    setDescription(initial?.description ?? '')
+    setSystemPrompt(initial?.systemPrompt ?? '')
+    setNotes(initial?.notes ?? '')
+    setTagsText((initial?.tags ?? []).join(', '))
+    setAvatarUrl(initial?.avatarUrl)
+    setAvatarError(null)
+  }, [initial])
+
+  function handleAvatarChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    e.target.value = ''
+    if (!file) return
+    if (!file.type.startsWith('image/')) {
+      setAvatarError('Please pick an image file (PNG, JPG, WEBP, GIF…).')
+      return
+    }
+    if (file.size > MAX_AVATAR_BYTES) {
+      setAvatarError(`Image is ${Math.round(file.size / 1024)}KB. Try one under ~1.5MB.`)
+      return
+    }
+    setAvatarError(null)
+    const reader = new FileReader()
+    reader.onload = () => setAvatarUrl(reader.result as string)
+    reader.onerror = () => setAvatarError('Could not read that image.')
+    reader.readAsDataURL(file)
+  }
+
+  function handleSave() {
+    if (!name.trim() || !systemPrompt.trim()) return
+    const tags = tagsText
+      .split(',')
+      .map((t) => t.trim().toLowerCase())
+      .filter(Boolean)
+      .slice(0, 8)
+    onSave({
+      name: name.trim().slice(0, 60),
+      emoji,
+      color,
+      description: description.trim().slice(0, 240),
+      systemPrompt: systemPrompt.trim(),
+      notes: notes.trim() || undefined,
+      tags,
+      avatarUrl,
+    })
+  }
+
+  return (
+    <div className={embedded ? 'flex flex-col gap-4' : 'flex flex-col gap-4 max-w-2xl'}>
+      {/* Avatar + name */}
+      <div className="flex items-start gap-4">
+        <div className="shrink-0 flex flex-col items-center gap-1.5">
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className="relative w-20 h-20 rounded-2xl border-2 border-dashed flex items-center justify-center overflow-hidden transition-colors hover:border-accent"
+            style={{
+              borderColor: avatarUrl ? color : 'var(--border)',
+              background: `${color}11`,
+            }}
+            title="Upload character image"
+          >
+            {avatarUrl ? (
+              <img src={avatarUrl} alt="Avatar" className="w-full h-full object-cover" />
+            ) : (
+              <div className="flex flex-col items-center gap-1 text-muted">
+                <ImageIcon size={20} />
+                <span className="text-[10px]">Upload</span>
+              </div>
+            )}
+          </button>
+          {avatarUrl && (
+            <button
+              type="button"
+              onClick={() => setAvatarUrl(undefined)}
+              className="text-[10px] text-muted hover:text-red-400 flex items-center gap-1"
+            >
+              <X size={10} />
+              Clear
+            </button>
+          )}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleAvatarChange}
+          />
+        </div>
+
+        <div className="flex-1 flex flex-col gap-2 min-w-0">
+          <div className="flex items-center gap-2">
+            <select
+              value={emoji}
+              onChange={(e) => setEmoji(e.target.value)}
+              className="input-field text-2xl w-14 text-center cursor-pointer"
+              style={{ paddingLeft: '0.25rem', paddingRight: '0.25rem' }}
+              title="Pick fallback emoji (used when no avatar)"
+            >
+              {EMOJI_OPTIONS.map((e) => (
+                <option key={e} value={e}>{e}</option>
+              ))}
+            </select>
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="input-field text-sm font-semibold flex-1"
+              placeholder="Character name"
+              maxLength={60}
+            />
+          </div>
+
+          <div>
+            <label className="text-[11px] text-muted mb-1 block">Accent color</label>
+            <div className="flex gap-1.5 flex-wrap">
+              {COLOR_OPTIONS.map((c) => (
+                <button
+                  key={c}
+                  type="button"
+                  onClick={() => setColor(c)}
+                  className="w-5 h-5 rounded-full transition-transform hover:scale-110"
+                  style={{
+                    background: c,
+                    outline: color === c ? `2px solid ${c}` : 'none',
+                    outlineOffset: '2px',
+                  }}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {avatarError && (
+        <div
+          className="text-xs px-3 py-2 rounded-lg flex items-center gap-2"
+          style={{
+            background: 'color-mix(in srgb, var(--danger) 15%, transparent)',
+            color: 'var(--danger)',
+          }}
+        >
+          <X size={12} />
+          {avatarError}
+        </div>
+      )}
+
+      <div>
+        <label className="text-xs text-muted mb-1 block">Short description</label>
+        <input
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="input-field text-xs"
+          placeholder="One-sentence hook for this character"
+          maxLength={240}
+        />
+      </div>
+
+      <div>
+        <label className="text-xs text-muted mb-1 block">Tags (comma separated)</label>
+        <input
+          value={tagsText}
+          onChange={(e) => setTagsText(e.target.value)}
+          className="input-field text-xs"
+          placeholder="roleplay, mysterious, sci-fi"
+        />
+      </div>
+
+      <div>
+        <label className="text-xs text-muted mb-1 block">System prompt</label>
+        <textarea
+          value={systemPrompt}
+          onChange={(e) => setSystemPrompt(e.target.value)}
+          rows={8}
+          className="input-field text-xs resize-y leading-relaxed font-mono"
+          placeholder="Define this character's identity, voice, behavior, knowledge, quirks, and limits…"
+        />
+      </div>
+
+      <div>
+        <label className="text-xs text-muted mb-1 block">
+          Notes &amp; lore <span className="opacity-60">(optional, for your reference)</span>
+        </label>
+        <textarea
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          rows={6}
+          className="input-field text-xs resize-y leading-relaxed"
+          placeholder="Markdown sheet — appearance, backstory, relationships, abilities, voice…"
+        />
+      </div>
+
+      <div className="flex gap-2 pt-1">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!name.trim() || !systemPrompt.trim()}
+          className="btn-primary text-xs flex-1 flex items-center justify-center gap-1.5 disabled:opacity-50"
+        >
+          <Save size={13} />
+          {saveLabel}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="btn-ghost text-xs flex-1 border border-subtle rounded-lg"
+          >
+            Cancel
+          </button>
+        )}
+        {onDelete && (
+          <button
+            type="button"
+            onClick={onDelete}
+            className="btn-ghost text-xs px-3 border border-subtle rounded-lg flex items-center gap-1.5"
+            style={{ color: 'var(--danger)' }}
+            title="Delete character"
+          >
+            <Trash2 size={13} />
+          </button>
+        )}
+      </div>
+
+      <p className="text-[11px] text-muted leading-relaxed">
+        <Upload size={11} className="inline mr-1 -mt-0.5" />
+        Image is stored locally with the character. Keep it small (under ~1.5MB) so chat exports stay light.
+      </p>
+    </div>
+  )
+}

--- a/src/components/characters/CharacterSelector.tsx
+++ b/src/components/characters/CharacterSelector.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { X, Plus, Edit2, Trash2, Check, Sparkles } from 'lucide-react'
+import { X, Plus, Edit2, Trash2, Check, Sparkles, Settings2 } from 'lucide-react'
 import { useChatStore } from '../../store/chatStore'
 import clsx from 'clsx'
 import type { Character } from '../../types'
@@ -7,6 +7,7 @@ import { AICharacterBuilder } from './AICharacterBuilder'
 
 interface CharacterSelectorProps {
   onClose: () => void
+  onOpenManager?: () => void
 }
 
 const EMOJI_OPTIONS = ['🌸', '💻', '✍️', '🧙', '🃏', '🔮', '🦊', '🐉', '🌙', '⚡', '🎯', '🧪', '🤖', '👾', '🦋']
@@ -105,7 +106,7 @@ function CharacterForm({
   )
 }
 
-export function CharacterSelector({ onClose }: CharacterSelectorProps) {
+export function CharacterSelector({ onClose, onOpenManager }: CharacterSelectorProps) {
   const characters = useChatStore((s) => s.characters)
   const activeChatId = useChatStore((s) => s.activeChatId)
   const chats = useChatStore((s) => s.chats)
@@ -147,9 +148,21 @@ export function CharacterSelector({ onClose }: CharacterSelectorProps) {
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 border-b border-subtle shrink-0">
           <h2 className="font-bold text-base">👤 Characters</h2>
-          <button onClick={onClose} className="btn-ghost p-1.5 rounded-lg">
-            <X size={16} />
-          </button>
+          <div className="flex items-center gap-1">
+            {onOpenManager && (
+              <button
+                onClick={onOpenManager}
+                className="btn-ghost text-xs flex items-center gap-1.5 border border-subtle rounded-lg"
+                title="Open the full Characters tab"
+              >
+                <Settings2 size={12} />
+                <span className="hidden sm:inline">Manage</span>
+              </button>
+            )}
+            <button onClick={onClose} className="btn-ghost p-1.5 rounded-lg">
+              <X size={16} />
+            </button>
+          </div>
         </div>
 
         <div className="flex-1 overflow-y-auto p-4 min-h-0">
@@ -234,12 +247,21 @@ export function CharacterSelector({ onClose }: CharacterSelectorProps) {
                 >
                   <div className="flex items-start justify-between gap-2">
                     <div className="flex items-center gap-2">
-                      <span
-                        className="text-2xl w-10 h-10 rounded-full flex items-center justify-center shrink-0"
-                        style={{ background: `${char.color}22` }}
-                      >
-                        {char.emoji}
-                      </span>
+                      {char.avatarUrl ? (
+                        <img
+                          src={char.avatarUrl}
+                          alt={char.name}
+                          className="w-10 h-10 rounded-full object-cover shrink-0"
+                          style={{ border: `1.5px solid ${char.color}` }}
+                        />
+                      ) : (
+                        <span
+                          className="text-2xl w-10 h-10 rounded-full flex items-center justify-center shrink-0"
+                          style={{ background: `${char.color}22` }}
+                        >
+                          {char.emoji}
+                        </span>
+                      )}
                       <div>
                         <div className="font-semibold text-sm" style={{ color: char.color }}>{char.name}</div>
                         <div className="text-xs text-muted line-clamp-1">{char.description}</div>

--- a/src/components/characters/CharacterTranscriber.tsx
+++ b/src/components/characters/CharacterTranscriber.tsx
@@ -1,0 +1,589 @@
+import { useRef, useState } from 'react'
+import {
+  Sparkles, RefreshCw, Upload, FileText, Image as ImageIcon, X,
+  AlertCircle, KeyRound, ChevronRight, ScrollText,
+} from 'lucide-react'
+import { useSettingsStore } from '../../store/settingsStore'
+import { completeChat } from '../../api/openrouter'
+import { ModelPicker } from '../models/ModelPicker'
+import type { Character } from '../../types'
+
+const EMOJI_OPTIONS = ['🌸', '💻', '✍️', '🧙', '🃏', '🔮', '🦊', '🐉', '🌙', '⚡', '🎯', '🧪', '🤖', '👾', '🦋']
+const COLOR_OPTIONS = ['#bd93f9', '#50fa7b', '#ffb86c', '#8be9fd', '#ff79c6', '#ff5555', '#f1fa8c', '#268bd2', '#2aa198', '#859900']
+
+// Dedicated transcriber/character-archivist prompt.
+// Distinct from the AI Idea builder — this one assumes you HAVE source material and just need it structured.
+const TRANSCRIBE_SYSTEM_PROMPT = `You are a Character Archivist & Transcriber. You ingest raw, messy source material about a character — pasted notes, file excerpts, descriptions, dialogue snippets, possibly reference images — and you produce a single clean, structured character sheet.
+
+Your method:
+1. Read EVERYTHING the user provides, including referenced images.
+2. Extract every concrete fact: name, aliases, age, species, appearance, voice, personality traits, history/background, relationships, motivations, fears, abilities, quirks, mannerisms, speech patterns, hard limits.
+3. Synthesize them faithfully into a JSON object matching the schema below. Do NOT invent contradictory facts. If a field is unspecified in the source, omit it or write a neutral inference clearly grounded in what's there.
+4. The "systemPrompt" must be a rich, second-person directive that lets a chat model BECOME this character: identity, voice, behavior, knowledge, quirks, hard limits. Aim for 180-400 words. Do not water down. Do not preach. Do not break the fourth wall. Do not refer to the character as an AI/model/assistant unless they explicitly are one.
+5. The "notes" field is a Markdown character sheet for the user's own reference. Use clearly labeled sections, e.g.:
+\`\`\`
+## Appearance
+## Personality
+## Background
+## Relationships
+## Abilities & Skills
+## Quirks & Mannerisms
+## Voice & Speech
+## Notes
+\`\`\`
+Pull every concrete detail from the source material into the right section. Use bullet points liberally.
+
+Schema:
+{
+  "name": string (max 60 chars; use the character's actual name from the source),
+  "emoji": single emoji from this set: ${EMOJI_OPTIONS.join(' ')} (pick whichever best fits the vibe),
+  "color": single hex string from this set: ${COLOR_OPTIONS.join(' ')},
+  "description": string (one short sentence, max 200 chars, hooks the reader),
+  "tags": string[] (3-6 lowercase one-word tags drawn from genre/role/personality),
+  "systemPrompt": string (180-400 words, second-person, vivid, in-character behavior directives),
+  "notes": string (Markdown character sheet built from the source material — sections + bullets)
+}
+
+Return ONLY the JSON object. No backticks. No commentary. No prose outside the JSON.`
+
+export interface TranscribedDraft {
+  name: string
+  emoji: string
+  color: string
+  description: string
+  tags: string[]
+  systemPrompt: string
+  notes: string
+}
+
+interface FileEntry {
+  id: string
+  name: string
+  kind: 'text' | 'image'
+  content: string
+  size: number
+}
+
+const MAX_TEXT_BYTES = 200_000
+const MAX_IMAGE_BYTES = 1_500_000
+const TEXT_EXTS = /\.(txt|md|markdown|json|csv|tsv|yml|yaml|html|htm|rtf|log|xml)$/i
+
+function fileKind(file: File): 'text' | 'image' | null {
+  if (file.type.startsWith('image/')) return 'image'
+  if (file.type.startsWith('text/')) return 'text'
+  if (file.type === 'application/json') return 'text'
+  if (TEXT_EXTS.test(file.name)) return 'text'
+  return null
+}
+
+function tryParseDraft(raw: string): TranscribedDraft | null {
+  let text = raw.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim()
+  const start = text.indexOf('{')
+  const end = text.lastIndexOf('}')
+  if (start === -1 || end === -1 || end <= start) return null
+  const slice = text.slice(start, end + 1)
+  try {
+    const obj = JSON.parse(slice)
+    if (typeof obj.name !== 'string' || typeof obj.systemPrompt !== 'string') return null
+    return {
+      name: String(obj.name).slice(0, 60),
+      emoji: typeof obj.emoji === 'string' && obj.emoji ? obj.emoji : '🤖',
+      color: typeof obj.color === 'string' && /^#[0-9a-f]{6}$/i.test(obj.color) ? obj.color : '#bd93f9',
+      description: typeof obj.description === 'string' ? obj.description.slice(0, 240) : '',
+      tags: Array.isArray(obj.tags) ? obj.tags.map(String).slice(0, 8) : [],
+      systemPrompt: String(obj.systemPrompt).trim(),
+      notes: typeof obj.notes === 'string' ? obj.notes.trim() : '',
+    }
+  } catch {
+    return null
+  }
+}
+
+interface CharacterTranscriberProps {
+  onAccept: (draft: Omit<Character, 'id' | 'isBuiltIn'>) => void
+  onCancel?: () => void
+}
+
+export function CharacterTranscriber({ onAccept, onCancel }: CharacterTranscriberProps) {
+  const mainKey = useSettingsStore((s) => s.apiKey)
+  const builderKey = useSettingsStore((s) => s.builderApiKey)
+  const effectiveKey = builderKey.trim() || mainKey
+  const usingBuilderKey = builderKey.trim().length > 0
+  const defaultModelId = useSettingsStore((s) => s.defaultModelId)
+
+  const [modelId, setModelId] = useState(defaultModelId)
+  const [showPicker, setShowPicker] = useState(false)
+  const [pastedText, setPastedText] = useState('')
+  const [files, setFiles] = useState<FileEntry[]>([])
+  const [refImages, setRefImages] = useState<FileEntry[]>([])
+  const [useRefAsAvatar, setUseRefAsAvatar] = useState(true)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [draft, setDraft] = useState<TranscribedDraft | null>(null)
+  const [rawOutput, setRawOutput] = useState<string | null>(null)
+  const [dragOver, setDragOver] = useState(false)
+
+  const textFileInputRef = useRef<HTMLInputElement>(null)
+  const imageFileInputRef = useRef<HTMLInputElement>(null)
+
+  function addFile(file: File) {
+    const kind = fileKind(file)
+    if (!kind) {
+      setError(`Skipped "${file.name}" — only text/markdown/json/csv and image files are supported.`)
+      return
+    }
+    const limit = kind === 'image' ? MAX_IMAGE_BYTES : MAX_TEXT_BYTES
+    if (file.size > limit) {
+      setError(`"${file.name}" is too large (${Math.round(file.size / 1024)}KB). Limit is ${Math.round(limit / 1024)}KB.`)
+      return
+    }
+    const reader = new FileReader()
+    reader.onload = () => {
+      const entry: FileEntry = {
+        id: Math.random().toString(36).slice(2, 9),
+        name: file.name,
+        kind,
+        content: reader.result as string,
+        size: file.size,
+      }
+      if (kind === 'image') {
+        setRefImages((prev) => [...prev, entry])
+      } else {
+        setFiles((prev) => [...prev, entry])
+      }
+    }
+    reader.onerror = () => setError(`Could not read "${file.name}".`)
+    if (kind === 'image') reader.readAsDataURL(file)
+    else reader.readAsText(file)
+  }
+
+  function handleTextFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const list = e.target.files
+    if (!list) return
+    Array.from(list).forEach(addFile)
+    e.target.value = ''
+  }
+
+  function handleImageFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const list = e.target.files
+    if (!list) return
+    Array.from(list).forEach(addFile)
+    e.target.value = ''
+  }
+
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault()
+    setDragOver(false)
+    const list = e.dataTransfer.files
+    if (!list) return
+    Array.from(list).forEach(addFile)
+  }
+
+  function removeFile(id: string) {
+    setFiles((prev) => prev.filter((f) => f.id !== id))
+  }
+
+  function removeImage(id: string) {
+    setRefImages((prev) => prev.filter((f) => f.id !== id))
+  }
+
+  const sourceCount = (pastedText.trim() ? 1 : 0) + files.length + refImages.length
+  const canGenerate = sourceCount > 0 && !!effectiveKey
+
+  async function handleGenerate() {
+    if (!effectiveKey) {
+      setError('No API key. Set your main or builder key in Settings first.')
+      return
+    }
+    if (sourceCount === 0) {
+      setError('Add some source material — paste text, attach files, or drop in a reference image.')
+      return
+    }
+    setIsLoading(true)
+    setError(null)
+    setDraft(null)
+    setRawOutput(null)
+
+    try {
+      const segments: string[] = []
+      if (pastedText.trim()) {
+        segments.push(`=== Pasted notes ===\n${pastedText.trim()}`)
+      }
+      for (const f of files) {
+        segments.push(`=== File: ${f.name} ===\n${f.content}`)
+      }
+      const userText = segments.length
+        ? `Source material follows. Synthesize a single character sheet that faithfully reflects every concrete detail.\n\n${segments.join('\n\n')}`
+        : 'The only source material is the attached reference image(s). Build the character sheet primarily from what you can see.'
+
+      const userContent: Array<
+        | { role: 'user'; content: string }
+      > = [
+        { role: 'user', content: userText },
+      ]
+
+      // Send reference images as multimodal user messages so vision-capable models can read them.
+      // We piggyback on the existing API by attaching one image per message.
+      // (completeChat supports a single imageUrl per message via the buildApiMessage helper.)
+      const imageMessages = refImages.map((img) => ({
+        role: 'user' as const,
+        content: 'Reference image for the character.',
+        imageUrl: img.content,
+      }))
+
+      const text = await completeChat({
+        apiKey: effectiveKey,
+        modelId,
+        systemPrompt: TRANSCRIBE_SYSTEM_PROMPT,
+        temperature: 0.7,
+        messages: [...userContent, ...imageMessages],
+      })
+
+      setRawOutput(text)
+      const parsed = tryParseDraft(text)
+      if (!parsed) {
+        setError("Model didn't return clean JSON. Try a stronger model, or trim the source down.")
+      } else {
+        setDraft(parsed)
+      }
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  function handleAccept() {
+    if (!draft) return
+    const avatarUrl = useRefAsAvatar && refImages.length > 0 ? refImages[0].content : undefined
+    onAccept({
+      name: draft.name,
+      emoji: draft.emoji,
+      color: draft.color,
+      description: draft.description,
+      tags: draft.tags,
+      systemPrompt: draft.systemPrompt,
+      notes: draft.notes || undefined,
+      avatarUrl,
+    })
+  }
+
+  return (
+    <>
+      <div className="flex flex-col gap-4 max-w-3xl">
+        <div
+          className="rounded-xl p-3 flex items-start gap-3 border"
+          style={{
+            background: 'color-mix(in srgb, var(--accent) 8%, var(--bg-tertiary))',
+            borderColor: 'color-mix(in srgb, var(--accent) 30%, var(--border))',
+          }}
+        >
+          <ScrollText size={16} style={{ color: 'var(--accent)' }} className="shrink-0 mt-0.5" />
+          <div className="text-xs leading-relaxed">
+            <div className="font-semibold mb-0.5">Transcribe a character</div>
+            <span className="text-muted">
+              Paste notes, drop in text/markdown/json files, attach reference images. The transcriber AI will
+              extract every key point and produce a structured, ready-to-roleplay character sheet.
+            </span>
+          </div>
+        </div>
+
+        {/* Model picker */}
+        <div>
+          <label className="text-xs text-muted mb-1.5 block">Transcriber model</label>
+          <button
+            onClick={() => setShowPicker(true)}
+            className="w-full flex items-center justify-between gap-2 input-field text-sm py-2 hover:border-accent transition-colors"
+          >
+            <span className="truncate font-mono text-xs">{modelId}</span>
+            <ChevronRight size={14} className="shrink-0 text-muted" />
+          </button>
+          <div className="flex items-center justify-between gap-2 mt-1.5">
+            <p className="text-xs text-muted">
+              Use a vision-capable model (e.g. GPT-4o, Claude, Gemini) if you attach reference images.
+            </p>
+            {usingBuilderKey && (
+              <span
+                className="shrink-0 text-[10px] px-2 py-0.5 rounded-full flex items-center gap-1 font-medium"
+                style={{
+                  background: 'color-mix(in srgb, var(--accent) 18%, transparent)',
+                  color: 'var(--accent)',
+                }}
+              >
+                <KeyRound size={10} />
+                Builder key
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Pasted text */}
+        <div>
+          <label className="text-xs text-muted mb-1.5 block">Paste notes / lore / dialogue</label>
+          <textarea
+            value={pastedText}
+            onChange={(e) => setPastedText(e.target.value)}
+            rows={6}
+            placeholder="Drop in any raw notes about your character — appearance, history, dialogue snippets, vibes, half-formed ideas…"
+            className="input-field text-sm resize-y leading-relaxed w-full"
+            disabled={isLoading}
+          />
+        </div>
+
+        {/* File drop zone */}
+        <div
+          onDragOver={(e) => { e.preventDefault(); setDragOver(true) }}
+          onDragLeave={() => setDragOver(false)}
+          onDrop={handleDrop}
+          className="rounded-xl border-2 border-dashed p-4 transition-colors"
+          style={{
+            borderColor: dragOver ? 'var(--accent)' : 'var(--border)',
+            background: dragOver ? 'color-mix(in srgb, var(--accent) 8%, transparent)' : 'transparent',
+          }}
+        >
+          <div className="flex flex-col items-center gap-2 text-center">
+            <Upload size={20} className="text-muted" />
+            <p className="text-sm font-medium">Drop files anywhere here</p>
+            <p className="text-xs text-muted">
+              .txt, .md, .json, .csv, .yaml, .xml, etc — and images for reference
+            </p>
+            <div className="flex gap-2 mt-1">
+              <button
+                onClick={() => textFileInputRef.current?.click()}
+                className="btn-ghost border border-subtle rounded-lg text-xs flex items-center gap-1.5"
+                disabled={isLoading}
+              >
+                <FileText size={13} />
+                Add text files
+              </button>
+              <button
+                onClick={() => imageFileInputRef.current?.click()}
+                className="btn-ghost border border-subtle rounded-lg text-xs flex items-center gap-1.5"
+                disabled={isLoading}
+              >
+                <ImageIcon size={13} />
+                Add images
+              </button>
+            </div>
+          </div>
+          <input
+            ref={textFileInputRef}
+            type="file"
+            multiple
+            accept=".txt,.md,.markdown,.json,.csv,.tsv,.yml,.yaml,.xml,.html,.htm,.log,.rtf,text/*,application/json"
+            className="hidden"
+            onChange={handleTextFileChange}
+          />
+          <input
+            ref={imageFileInputRef}
+            type="file"
+            multiple
+            accept="image/*"
+            className="hidden"
+            onChange={handleImageFileChange}
+          />
+        </div>
+
+        {/* Attached files list */}
+        {(files.length > 0 || refImages.length > 0) && (
+          <div className="flex flex-col gap-2">
+            {files.length > 0 && (
+              <div className="flex flex-col gap-1">
+                <div className="text-xs text-muted">Text sources ({files.length})</div>
+                {files.map((f) => (
+                  <div
+                    key={f.id}
+                    className="flex items-center gap-2 p-2 rounded-lg border border-subtle"
+                    style={{ background: 'var(--bg-tertiary)' }}
+                  >
+                    <FileText size={13} className="shrink-0 text-muted" />
+                    <span className="text-xs truncate flex-1">{f.name}</span>
+                    <span className="text-[10px] text-muted shrink-0">{Math.round(f.size / 1024)}KB</span>
+                    <button onClick={() => removeFile(f.id)} className="btn-ghost p-1 rounded">
+                      <X size={11} />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {refImages.length > 0 && (
+              <div className="flex flex-col gap-1">
+                <div className="text-xs text-muted">Reference images ({refImages.length})</div>
+                <div className="flex flex-wrap gap-2">
+                  {refImages.map((img) => (
+                    <div
+                      key={img.id}
+                      className="relative w-20 h-20 rounded-lg overflow-hidden border border-subtle group"
+                    >
+                      <img src={img.content} alt={img.name} className="w-full h-full object-cover" />
+                      <button
+                        onClick={() => removeImage(img.id)}
+                        className="absolute top-1 right-1 p-0.5 rounded-md opacity-0 group-hover:opacity-100 transition-opacity"
+                        style={{ background: 'rgba(0,0,0,0.6)', color: 'white' }}
+                      >
+                        <X size={11} />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+                <label className="flex items-center gap-2 text-xs text-muted mt-1 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={useRefAsAvatar}
+                    onChange={(e) => setUseRefAsAvatar(e.target.checked)}
+                  />
+                  Use the first reference image as the character&apos;s avatar
+                </label>
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className="flex gap-2">
+          <button
+            onClick={handleGenerate}
+            disabled={isLoading || !canGenerate}
+            className="btn-primary text-sm flex items-center justify-center gap-2 disabled:opacity-50 flex-1"
+          >
+            {isLoading ? (
+              <>
+                <RefreshCw size={14} className="animate-spin" />
+                Reading the source…
+              </>
+            ) : (
+              <>
+                <Sparkles size={14} />
+                Transcribe to Character Sheet
+              </>
+            )}
+          </button>
+          {onCancel && (
+            <button
+              onClick={onCancel}
+              className="btn-ghost text-sm border border-subtle rounded-lg px-4"
+              disabled={isLoading}
+            >
+              Cancel
+            </button>
+          )}
+        </div>
+
+        {error && (
+          <div
+            className="flex items-start gap-2 text-xs p-3 rounded-lg"
+            style={{
+              background: 'color-mix(in srgb, var(--danger) 15%, transparent)',
+              color: 'var(--danger)',
+            }}
+          >
+            <AlertCircle size={14} className="shrink-0 mt-0.5" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        {/* Preview */}
+        {draft && (
+          <div
+            className="rounded-xl border p-4 flex flex-col gap-3"
+            style={{ borderColor: draft.color, background: 'var(--bg-tertiary)' }}
+          >
+            <div className="flex items-center gap-3">
+              {useRefAsAvatar && refImages.length > 0 ? (
+                <img
+                  src={refImages[0].content}
+                  alt="Avatar preview"
+                  className="w-14 h-14 rounded-2xl object-cover shrink-0"
+                  style={{ border: `2px solid ${draft.color}` }}
+                />
+              ) : (
+                <span
+                  className="text-3xl w-14 h-14 rounded-2xl flex items-center justify-center shrink-0"
+                  style={{ background: `${draft.color}22` }}
+                >
+                  {draft.emoji}
+                </span>
+              )}
+              <div className="min-w-0 flex-1">
+                <div className="font-bold text-base" style={{ color: draft.color }}>{draft.name}</div>
+                {draft.description && (
+                  <div className="text-xs text-muted">{draft.description}</div>
+                )}
+              </div>
+            </div>
+
+            {draft.tags.length > 0 && (
+              <div className="flex flex-wrap gap-1">
+                {draft.tags.map((t) => (
+                  <span
+                    key={t}
+                    className="text-[10px] px-2 py-0.5 rounded-full"
+                    style={{ background: 'var(--bg-secondary)', color: 'var(--text-secondary)' }}
+                  >
+                    {t}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            <details>
+              <summary className="text-xs text-muted cursor-pointer">System prompt</summary>
+              <p
+                className="text-xs leading-relaxed max-h-48 overflow-y-auto p-2 mt-1.5 rounded-md font-mono whitespace-pre-wrap"
+                style={{ background: 'var(--bg-secondary)' }}
+              >
+                {draft.systemPrompt}
+              </p>
+            </details>
+
+            {draft.notes && (
+              <details open>
+                <summary className="text-xs text-muted cursor-pointer">Character sheet</summary>
+                <pre
+                  className="text-xs leading-relaxed max-h-72 overflow-y-auto p-2 mt-1.5 rounded-md whitespace-pre-wrap break-words"
+                  style={{ background: 'var(--bg-secondary)' }}
+                >
+                  {draft.notes}
+                </pre>
+              </details>
+            )}
+
+            <div className="flex gap-2">
+              <button onClick={handleAccept} className="btn-primary text-xs flex-1">
+                Save to Library
+              </button>
+              <button
+                onClick={handleGenerate}
+                disabled={isLoading}
+                className="btn-ghost text-xs flex-1 border border-subtle rounded-lg"
+              >
+                Reroll
+              </button>
+            </div>
+          </div>
+        )}
+
+        {!draft && rawOutput && (
+          <details className="text-xs text-muted">
+            <summary className="cursor-pointer">Show raw model output</summary>
+            <pre
+              className="mt-2 p-2 rounded-md font-mono text-[11px] whitespace-pre-wrap break-words max-h-48 overflow-y-auto"
+              style={{ background: 'var(--bg-tertiary)' }}
+            >
+              {rawOutput}
+            </pre>
+          </details>
+        )}
+      </div>
+
+      {showPicker && (
+        <ModelPicker
+          onClose={() => setShowPicker(false)}
+          title="Pick Transcriber Model"
+          currentModelIdOverride={modelId}
+          onSelectModel={(id) => setModelId(id)}
+        />
+      )}
+    </>
+  )
+}

--- a/src/components/characters/CharactersPage.tsx
+++ b/src/components/characters/CharactersPage.tsx
@@ -1,0 +1,525 @@
+import { useMemo, useState } from 'react'
+import {
+  Users, Plus, ScrollText, Sparkles, Search, MessageSquarePlus, Edit2, Trash2,
+  Lock, Check, X, ArrowLeft, Wand2,
+} from 'lucide-react'
+import clsx from 'clsx'
+import { useChatStore } from '../../store/chatStore'
+import { useSettingsStore } from '../../store/settingsStore'
+import type { Character } from '../../types'
+import { CharacterEditor } from './CharacterEditor'
+import { CharacterTranscriber } from './CharacterTranscriber'
+import { AICharacterBuilder } from './AICharacterBuilder'
+
+type Tab = 'library' | 'create' | 'transcribe' | 'idea'
+
+interface CharactersPageProps {
+  onBackToChat: () => void
+}
+
+export function CharactersPage({ onBackToChat }: CharactersPageProps) {
+  const characters = useChatStore((s) => s.characters)
+  const activeChatId = useChatStore((s) => s.activeChatId)
+  const chats = useChatStore((s) => s.chats)
+  const updateChat = useChatStore((s) => s.updateChat)
+  const createChat = useChatStore((s) => s.createChat)
+  const setActiveChatId = useChatStore((s) => s.setActiveChatId)
+  const addCharacter = useChatStore((s) => s.addCharacter)
+  const updateCharacter = useChatStore((s) => s.updateCharacter)
+  const deleteCharacter = useChatStore((s) => s.deleteCharacter)
+  const defaultModelId = useSettingsStore((s) => s.defaultModelId)
+  const apiKey = useSettingsStore((s) => s.apiKey)
+
+  const [tab, setTab] = useState<Tab>('library')
+  const [search, setSearch] = useState('')
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [creatingFromDraft, setCreatingFromDraft] = useState<Partial<Character> | null>(null)
+  const [punchUpId, setPunchUpId] = useState<string | null>(null)
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null)
+
+  const activeChat = chats.find((c) => c.id === activeChatId) ?? null
+  const punchUpTarget = punchUpId ? characters.find((c) => c.id === punchUpId) ?? null : null
+  const editingTarget = editingId ? characters.find((c) => c.id === editingId) ?? null : null
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    if (!q) return characters
+    return characters.filter((c) =>
+      c.name.toLowerCase().includes(q) ||
+      c.description.toLowerCase().includes(q) ||
+      c.tags.some((t) => t.toLowerCase().includes(q))
+    )
+  }, [characters, search])
+
+  function useInChat(char: Character) {
+    if (activeChat) {
+      updateChat(activeChat.id, { characterId: char.id, systemPrompt: char.systemPrompt })
+      onBackToChat()
+      return
+    }
+    if (!apiKey) {
+      // Still create the chat — the chat view will prompt for the key on send.
+    }
+    const id = createChat(defaultModelId)
+    updateChat(id, { characterId: char.id, systemPrompt: char.systemPrompt })
+    setActiveChatId(id)
+    onBackToChat()
+  }
+
+  function startNewChatWith(char: Character) {
+    const id = createChat(defaultModelId)
+    updateChat(id, { characterId: char.id, systemPrompt: char.systemPrompt })
+    setActiveChatId(id)
+    onBackToChat()
+  }
+
+  function handleCreateSave(draft: Omit<Character, 'id' | 'isBuiltIn'>) {
+    addCharacter(draft)
+    setCreatingFromDraft(null)
+    setTab('library')
+  }
+
+  function handleEditSave(draft: Omit<Character, 'id' | 'isBuiltIn'>) {
+    if (!editingId) return
+    updateCharacter(editingId, draft)
+    setEditingId(null)
+  }
+
+  function handleDelete(id: string) {
+    if (confirmDeleteId === id) {
+      deleteCharacter(id)
+      setConfirmDeleteId(null)
+      if (editingId === id) setEditingId(null)
+    } else {
+      setConfirmDeleteId(id)
+      setTimeout(() => setConfirmDeleteId(null), 2500)
+    }
+  }
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0 app-bg">
+      {/* Header */}
+      <header
+        className="flex items-center justify-between px-4 py-3 border-b border-subtle shrink-0"
+        style={{ background: 'var(--bg-secondary)' }}
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          <button
+            onClick={onBackToChat}
+            className="btn-ghost p-1.5 rounded-lg flex items-center gap-1.5"
+            title="Back to chat"
+          >
+            <ArrowLeft size={15} />
+          </button>
+          <Users size={16} style={{ color: 'var(--accent)' }} />
+          <h2 className="font-bold text-base">Characters</h2>
+          <span className="text-xs text-muted hidden sm:inline">
+            ({characters.length})
+          </span>
+        </div>
+
+        {/* Tabs */}
+        <nav className="flex items-center gap-1 p-1 rounded-xl border border-subtle"
+          style={{ background: 'var(--bg-tertiary)' }}
+        >
+          <TabButton active={tab === 'library'} onClick={() => setTab('library')} icon={<Users size={13} />}>
+            Library
+          </TabButton>
+          <TabButton active={tab === 'create'} onClick={() => { setCreatingFromDraft(null); setTab('create') }} icon={<Plus size={13} />}>
+            Create
+          </TabButton>
+          <TabButton active={tab === 'transcribe'} onClick={() => setTab('transcribe')} icon={<ScrollText size={13} />}>
+            Transcribe
+          </TabButton>
+          <TabButton active={tab === 'idea'} onClick={() => setTab('idea')} icon={<Sparkles size={13} />}>
+            AI Idea
+          </TabButton>
+        </nav>
+      </header>
+
+      {/* Body */}
+      <div className="flex-1 overflow-y-auto min-h-0 p-4">
+        {tab === 'library' && (
+          <LibraryView
+            characters={filtered}
+            search={search}
+            onSearchChange={setSearch}
+            activeCharacterId={activeChat?.characterId ?? null}
+            hasActiveChat={!!activeChat}
+            onUseInChat={useInChat}
+            onStartNewChat={startNewChatWith}
+            onEdit={(id) => setEditingId(id)}
+            onPunchUp={(id) => setPunchUpId(id)}
+            onDelete={handleDelete}
+            confirmDeleteId={confirmDeleteId}
+            onClearActive={() => {
+              if (activeChat) {
+                updateChat(activeChat.id, { characterId: null, systemPrompt: '' })
+                onBackToChat()
+              }
+            }}
+          />
+        )}
+
+        {tab === 'create' && (
+          <div className="max-w-2xl mx-auto">
+            <h3 className="font-semibold text-sm mb-3 flex items-center gap-2">
+              <Plus size={14} />
+              {creatingFromDraft ? 'Create — AI draft loaded' : 'Create a character from scratch'}
+            </h3>
+            <CharacterEditor
+              initial={creatingFromDraft ?? undefined}
+              onSave={handleCreateSave}
+              onCancel={() => { setCreatingFromDraft(null); setTab('library') }}
+              saveLabel="Add to Library"
+            />
+          </div>
+        )}
+
+        {tab === 'transcribe' && (
+          <div className="max-w-3xl mx-auto">
+            <h3 className="font-semibold text-sm mb-3 flex items-center gap-2">
+              <ScrollText size={14} />
+              Transcribe a character from source material
+            </h3>
+            <CharacterTranscriber
+              onAccept={(draft) => {
+                setCreatingFromDraft(draft)
+                setTab('create')
+              }}
+              onCancel={() => setTab('library')}
+            />
+          </div>
+        )}
+
+        {tab === 'idea' && (
+          <div className="max-w-2xl mx-auto">
+            <IdeaPanel
+              onDraft={(draft) => {
+                setCreatingFromDraft(draft)
+                setTab('create')
+              }}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Edit modal */}
+      {editingTarget && (
+        <div
+          className="fixed inset-0 z-40 flex items-center justify-center p-4"
+          style={{ background: 'rgba(0,0,0,0.7)' }}
+          onClick={(e) => { if (e.target === e.currentTarget) setEditingId(null) }}
+        >
+          <div
+            className="w-full max-w-2xl max-h-[90vh] rounded-2xl flex flex-col shadow-2xl fade-in"
+            style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border)' }}
+          >
+            <div className="flex items-center justify-between px-4 py-3 border-b border-subtle shrink-0">
+              <h3 className="font-bold text-base flex items-center gap-2">
+                <Edit2 size={14} />
+                Edit Character
+                {editingTarget.isBuiltIn && (
+                  <span className="text-[10px] px-2 py-0.5 rounded-full text-muted flex items-center gap-1"
+                    style={{ background: 'var(--bg-tertiary)' }}
+                  >
+                    <Lock size={9} /> Built-in
+                  </span>
+                )}
+              </h3>
+              <button onClick={() => setEditingId(null)} className="btn-ghost p-1.5 rounded-lg">
+                <X size={16} />
+              </button>
+            </div>
+            <div className="flex-1 overflow-y-auto p-4 min-h-0">
+              {editingTarget.isBuiltIn ? (
+                <div className="text-xs text-muted mb-3 px-3 py-2 rounded-lg"
+                  style={{ background: 'var(--bg-tertiary)' }}
+                >
+                  Built-in characters are read-only. Use “Punch Up” to fork a customized copy, or copy the
+                  fields into a new Create.
+                </div>
+              ) : null}
+              {!editingTarget.isBuiltIn && (
+                <CharacterEditor
+                  initial={editingTarget}
+                  onSave={handleEditSave}
+                  onCancel={() => setEditingId(null)}
+                  onDelete={() => handleDelete(editingTarget.id)}
+                  saveLabel="Save Changes"
+                  embedded
+                />
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Punch up */}
+      {punchUpTarget && (
+        <AICharacterBuilder
+          mode={{ kind: 'rewrite', existing: punchUpTarget }}
+          onClose={() => setPunchUpId(null)}
+          onAccept={(draft) => {
+            updateCharacter(punchUpTarget.id, draft)
+            setPunchUpId(null)
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+function TabButton({
+  active, onClick, icon, children,
+}: {
+  active: boolean
+  onClick: () => void
+  icon: React.ReactNode
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={clsx(
+        'flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium transition-colors',
+        active ? 'text-white' : 'text-muted hover:text-primary'
+      )}
+      style={active ? { background: 'var(--accent)', color: 'white' } : undefined}
+    >
+      {icon}
+      <span className="hidden sm:inline">{children}</span>
+    </button>
+  )
+}
+
+interface LibraryViewProps {
+  characters: Character[]
+  search: string
+  onSearchChange: (q: string) => void
+  activeCharacterId: string | null
+  hasActiveChat: boolean
+  onUseInChat: (char: Character) => void
+  onStartNewChat: (char: Character) => void
+  onEdit: (id: string) => void
+  onPunchUp: (id: string) => void
+  onDelete: (id: string) => void
+  confirmDeleteId: string | null
+  onClearActive: () => void
+}
+
+function LibraryView({
+  characters, search, onSearchChange,
+  activeCharacterId, hasActiveChat,
+  onUseInChat, onStartNewChat, onEdit, onPunchUp, onDelete, confirmDeleteId, onClearActive,
+}: LibraryViewProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-2 flex-wrap">
+        <div
+          className="flex items-center gap-2 px-3 py-2 rounded-lg border border-subtle flex-1 min-w-[200px]"
+          style={{ background: 'var(--bg-tertiary)' }}
+        >
+          <Search size={13} className="text-muted shrink-0" />
+          <input
+            value={search}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder="Search by name, description, or tag…"
+            className="bg-transparent outline-none text-sm flex-1 min-w-0"
+            style={{ color: 'var(--text-primary)' }}
+          />
+        </div>
+        {hasActiveChat && activeCharacterId && (
+          <button
+            onClick={onClearActive}
+            className="btn-ghost text-xs border border-subtle rounded-lg flex items-center gap-1.5"
+          >
+            <X size={12} />
+            Clear from current chat
+          </button>
+        )}
+      </div>
+
+      {characters.length === 0 && (
+        <div className="text-center py-16 text-muted text-sm">
+          No characters match. Try a different search, or create one!
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+        {characters.map((char) => (
+          <CharacterCard
+            key={char.id}
+            character={char}
+            isActive={activeCharacterId === char.id}
+            hasActiveChat={hasActiveChat}
+            confirmDelete={confirmDeleteId === char.id}
+            onUseInChat={() => onUseInChat(char)}
+            onStartNewChat={() => onStartNewChat(char)}
+            onEdit={() => onEdit(char.id)}
+            onPunchUp={() => onPunchUp(char.id)}
+            onDelete={() => onDelete(char.id)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+interface CharacterCardProps {
+  character: Character
+  isActive: boolean
+  hasActiveChat: boolean
+  confirmDelete: boolean
+  onUseInChat: () => void
+  onStartNewChat: () => void
+  onEdit: () => void
+  onPunchUp: () => void
+  onDelete: () => void
+}
+
+function CharacterCard({
+  character: char, isActive, hasActiveChat, confirmDelete,
+  onUseInChat, onStartNewChat, onEdit, onPunchUp, onDelete,
+}: CharacterCardProps) {
+  return (
+    <div
+      className="relative rounded-2xl border p-4 flex flex-col gap-3 transition-all"
+      style={{
+        borderColor: isActive ? char.color : 'var(--border)',
+        background: isActive
+          ? `color-mix(in srgb, ${char.color} 8%, var(--bg-secondary))`
+          : 'var(--bg-secondary)',
+      }}
+    >
+      {isActive && (
+        <span
+          className="absolute top-3 right-3 text-[10px] px-2 py-0.5 rounded-full font-semibold flex items-center gap-1"
+          style={{ background: char.color, color: 'white' }}
+        >
+          <Check size={10} />
+          Active
+        </span>
+      )}
+
+      <div className="flex items-start gap-3">
+        {char.avatarUrl ? (
+          <img
+            src={char.avatarUrl}
+            alt={char.name}
+            className="w-14 h-14 rounded-2xl object-cover shrink-0"
+            style={{ border: `2px solid ${char.color}` }}
+          />
+        ) : (
+          <span
+            className="w-14 h-14 rounded-2xl flex items-center justify-center text-3xl shrink-0"
+            style={{ background: `${char.color}22` }}
+          >
+            {char.emoji}
+          </span>
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="font-bold text-sm truncate" style={{ color: char.color }}>{char.name}</div>
+          <div className="text-xs text-muted line-clamp-2 mt-0.5">{char.description}</div>
+          {char.tags.length > 0 && (
+            <div className="flex flex-wrap gap-1 mt-1.5">
+              {char.tags.slice(0, 4).map((t) => (
+                <span
+                  key={t}
+                  className="text-[10px] px-1.5 py-0.5 rounded-full"
+                  style={{ background: 'var(--bg-tertiary)', color: 'var(--text-secondary)' }}
+                >
+                  {t}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="flex gap-1.5 flex-wrap">
+        <button
+          onClick={onUseInChat}
+          className="btn-primary text-xs flex-1 flex items-center justify-center gap-1 py-1.5 rounded-lg"
+          title={hasActiveChat ? 'Use in current chat' : 'Start a chat with this character'}
+        >
+          <Check size={12} />
+          {hasActiveChat ? 'Use Here' : 'Start Chat'}
+        </button>
+        {hasActiveChat && (
+          <button
+            onClick={onStartNewChat}
+            className="btn-ghost text-xs border border-subtle rounded-lg p-1.5"
+            title="Start a brand-new chat with this character"
+          >
+            <MessageSquarePlus size={12} />
+          </button>
+        )}
+        {!char.isBuiltIn && (
+          <>
+            <button
+              onClick={onPunchUp}
+              className="btn-ghost text-xs border border-subtle rounded-lg p-1.5"
+              title="AI punch up"
+              style={{ color: 'var(--accent)' }}
+            >
+              <Wand2 size={12} />
+            </button>
+            <button
+              onClick={onEdit}
+              className="btn-ghost text-xs border border-subtle rounded-lg p-1.5"
+              title="Edit"
+            >
+              <Edit2 size={12} />
+            </button>
+            <button
+              onClick={onDelete}
+              className="btn-ghost text-xs border border-subtle rounded-lg p-1.5"
+              style={{ color: confirmDelete ? 'var(--danger)' : undefined }}
+              title={confirmDelete ? 'Click again to confirm delete' : 'Delete'}
+            >
+              <Trash2 size={12} />
+            </button>
+          </>
+        )}
+        {char.isBuiltIn && (
+          <span
+            className="text-[10px] px-2 py-1 rounded-lg flex items-center gap-1 text-muted"
+            style={{ background: 'var(--bg-tertiary)' }}
+            title="Built-in characters can't be edited, but you can fork them"
+          >
+            <Lock size={10} />
+            Built-in
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function IdeaPanel({ onDraft }: { onDraft: (draft: Partial<Character>) => void }) {
+  const [open, setOpen] = useState(true)
+  return (
+    <>
+      <h3 className="font-semibold text-sm mb-3 flex items-center gap-2">
+        <Sparkles size={14} style={{ color: 'var(--accent)' }} />
+        Spin one up from a single idea
+      </h3>
+      <p className="text-xs text-muted mb-4 leading-relaxed">
+        Got a one-liner brief but no source material? Use the idea-based AI builder. It’ll invent personality,
+        voice, and quirks for you. (For uploading existing source material, use the Transcribe tab.)
+      </p>
+      {open ? (
+        <AICharacterBuilder
+          onClose={() => setOpen(false)}
+          onAccept={(draft) => onDraft(draft)}
+        />
+      ) : (
+        <button onClick={() => setOpen(true)} className="btn-primary text-sm flex items-center gap-2">
+          <Sparkles size={14} />
+          Open AI Idea Builder
+        </button>
+      )}
+    </>
+  )
+}

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -104,7 +104,15 @@ export function ChatInput({
         >
           {character ? (
             <>
-              <span>{character.emoji}</span>
+              {character.avatarUrl ? (
+                <img
+                  src={character.avatarUrl}
+                  alt=""
+                  className="w-4 h-4 rounded-full object-cover"
+                />
+              ) : (
+                <span>{character.emoji}</span>
+              )}
               <span>{character.name}</span>
             </>
           ) : (

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -11,6 +11,7 @@ interface ChatViewProps {
   onOpenModelPicker: () => void
   onOpenPrompts: () => void
   onOpenCharacters: () => void
+  onOpenCharactersPage: () => void
   onNeedApiKey: () => void
 }
 
@@ -18,6 +19,7 @@ export function ChatView({
   onOpenModelPicker,
   onOpenPrompts,
   onOpenCharacters,
+  onOpenCharactersPage,
   onNeedApiKey,
 }: ChatViewProps) {
   const chats = useChatStore((s) => s.chats)
@@ -99,8 +101,8 @@ export function ChatView({
           <ActionCard
             icon={<Users size={18} />}
             title="Characters"
-            description="Choose a persona for the AI"
-            onClick={onOpenCharacters}
+            description="Browse, create, & transcribe personas"
+            onClick={onOpenCharactersPage}
           />
           <ActionCard
             icon={<BookOpen size={18} />}
@@ -124,9 +126,23 @@ export function ChatView({
       >
         <div className="flex items-center gap-2 min-w-0">
           {character && (
-            <span className="text-lg" title={character.name}>
-              {character.emoji}
-            </span>
+            character.avatarUrl ? (
+              <img
+                src={character.avatarUrl}
+                alt={character.name}
+                className="w-7 h-7 rounded-full object-cover shrink-0"
+                style={{ border: `1.5px solid ${character.color}` }}
+                title={character.name}
+              />
+            ) : (
+              <span
+                className="w-7 h-7 rounded-full flex items-center justify-center text-base shrink-0"
+                style={{ background: `${character.color}22` }}
+                title={character.name}
+              >
+                {character.emoji}
+              </span>
+            )
           )}
           <h2 className="font-semibold text-sm truncate">{activeChat.title}</h2>
         </div>
@@ -161,6 +177,7 @@ export function ChatView({
             key={msg.id}
             message={msg}
             chatId={activeChat.id}
+            character={character}
             isLast={idx === visibleMessages.length - 1}
             isStreaming={isStreaming}
             onBookmark={(msgId) => toggleBookmarkMessage(activeChat.id, msgId)}

--- a/src/components/chat/Message.tsx
+++ b/src/components/chat/Message.tsx
@@ -5,11 +5,12 @@ import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
 import { Copy, Check, Bookmark, BookmarkCheck, Edit2, RefreshCw, GitBranch, X } from 'lucide-react'
 import clsx from 'clsx'
-import type { Message as MessageType } from '../../types'
+import type { Message as MessageType, Character } from '../../types'
 
 interface MessageProps {
   message: MessageType
   chatId: string
+  character?: Character | null
   isLast?: boolean
   isStreaming?: boolean
   onBookmark: (messageId: string) => void
@@ -44,6 +45,7 @@ function estimateCost(tokenCount: number): string | null {
 export function Message({
   message,
   chatId: _chatId,
+  character,
   isLast,
   isStreaming,
   onBookmark,
@@ -52,6 +54,7 @@ export function Message({
   onBranch,
 }: MessageProps) {
   const isUser = message.role === 'user'
+  const showCharAvatar = !isUser && !!character
   const [editing, setEditing] = useState(false)
   const [editDraft, setEditDraft] = useState(message.content)
 
@@ -75,19 +78,37 @@ export function Message({
         isUser ? 'flex-row-reverse' : 'flex-row'
       )}
     >
-      {/* Avatar dot */}
-      <div
-        className={clsx(
-          'shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold mt-0.5',
-        )}
-        style={
-          isUser
-            ? { background: 'var(--accent)', color: 'white' }
-            : { background: 'var(--surface)', color: 'var(--text-secondary)' }
-        }
-      >
-        {isUser ? 'U' : 'AI'}
-      </div>
+      {/* Avatar */}
+      {showCharAvatar && character ? (
+        character.avatarUrl ? (
+          <img
+            src={character.avatarUrl}
+            alt={character.name}
+            className="shrink-0 w-7 h-7 rounded-full object-cover mt-0.5"
+            style={{ border: `1.5px solid ${character.color}` }}
+            title={character.name}
+          />
+        ) : (
+          <div
+            className="shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-base mt-0.5"
+            style={{ background: `${character.color}22` }}
+            title={character.name}
+          >
+            {character.emoji}
+          </div>
+        )
+      ) : (
+        <div
+          className="shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold mt-0.5"
+          style={
+            isUser
+              ? { background: 'var(--accent)', color: 'white' }
+              : { background: 'var(--surface)', color: 'var(--text-secondary)' }
+          }
+        >
+          {isUser ? 'U' : 'AI'}
+        </div>
+      )}
 
       {/* Bubble */}
       <div className={clsx('flex flex-col gap-1 max-w-[80%]', isUser ? 'items-end' : 'items-start')}>

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -5,9 +5,17 @@ interface AppLayoutProps {
   children: React.ReactNode
   onOpenSettings: () => void
   onOpenBookmarks: () => void
+  view: 'chat' | 'characters'
+  onChangeView: (v: 'chat' | 'characters') => void
 }
 
-export function AppLayout({ children, onOpenSettings, onOpenBookmarks }: AppLayoutProps) {
+export function AppLayout({
+  children,
+  onOpenSettings,
+  onOpenBookmarks,
+  view,
+  onChangeView,
+}: AppLayoutProps) {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
 
   return (
@@ -17,6 +25,8 @@ export function AppLayout({ children, onOpenSettings, onOpenBookmarks }: AppLayo
         onToggle={() => setSidebarCollapsed((v) => !v)}
         onOpenSettings={onOpenSettings}
         onOpenBookmarks={onOpenBookmarks}
+        view={view}
+        onChangeView={onChangeView}
       />
       <main className="flex-1 flex flex-col min-w-0 overflow-hidden">
         {children}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef } from 'react'
 import {
   MessageSquare, Plus, Trash2, Settings, ChevronLeft, ChevronRight,
-  Download, Upload, Pin, PinOff, Search, Bookmark, ChevronDown,
+  Download, Upload, Pin, PinOff, Search, Bookmark, ChevronDown, Users,
 } from 'lucide-react'
 import { useChatStore } from '../../store/chatStore'
 import { useSettingsStore } from '../../store/settingsStore'
@@ -13,9 +13,13 @@ interface SidebarProps {
   onToggle: () => void
   onOpenSettings: () => void
   onOpenBookmarks: () => void
+  view: 'chat' | 'characters'
+  onChangeView: (v: 'chat' | 'characters') => void
 }
 
-export function Sidebar({ collapsed, onToggle, onOpenSettings, onOpenBookmarks }: SidebarProps) {
+export function Sidebar({
+  collapsed, onToggle, onOpenSettings, onOpenBookmarks, view, onChangeView,
+}: SidebarProps) {
   const chats = useChatStore((s) => s.chats)
   const activeChatId = useChatStore((s) => s.activeChatId)
   const createChat = useChatStore((s) => s.createChat)
@@ -35,6 +39,7 @@ export function Sidebar({ collapsed, onToggle, onOpenSettings, onOpenBookmarks }
 
   function handleNewChat() {
     createChat(defaultModelId)
+    onChangeView('chat')
   }
 
   function handleDeleteChat(id: string, e: React.MouseEvent) {
@@ -87,7 +92,7 @@ export function Sidebar({ collapsed, onToggle, onOpenSettings, onOpenBookmarks }
     return (
       <button
         key={chat.id}
-        onClick={() => setActiveChatId(chat.id)}
+        onClick={() => { setActiveChatId(chat.id); onChangeView('chat') }}
         className={clsx(
           'w-full flex items-center gap-2 px-2 py-2 mx-0 rounded-md text-left text-sm group transition-colors relative',
           isActive ? 'bg-accent text-white' : 'hover:bg-tertiary'
@@ -164,6 +169,40 @@ export function Sidebar({ collapsed, onToggle, onOpenSettings, onOpenBookmarks }
         >
           <Plus size={16} />
           {!collapsed && <span>New Chat</span>}
+        </button>
+      </div>
+
+      {/* View tabs */}
+      <div className="px-2 pb-2 shrink-0 flex flex-col gap-1">
+        <button
+          onClick={() => onChangeView('chat')}
+          className={clsx(
+            'flex items-center gap-2 w-full text-sm rounded-lg px-2 py-1.5 transition-colors',
+            collapsed ? 'justify-center' : 'justify-start',
+            view === 'chat' ? 'tab-active' : 'btn-ghost'
+          )}
+          style={view === 'chat'
+            ? { background: 'var(--bg-tertiary)', color: 'var(--text-primary)' }
+            : undefined}
+          title="Chats"
+        >
+          <MessageSquare size={15} />
+          {!collapsed && <span className="font-medium">Chats</span>}
+        </button>
+        <button
+          onClick={() => onChangeView('characters')}
+          className={clsx(
+            'flex items-center gap-2 w-full text-sm rounded-lg px-2 py-1.5 transition-colors',
+            collapsed ? 'justify-center' : 'justify-start',
+            view === 'characters' ? '' : 'btn-ghost'
+          )}
+          style={view === 'characters'
+            ? { background: 'var(--bg-tertiary)', color: 'var(--text-primary)' }
+            : undefined}
+          title="Characters (Ctrl+Shift+P)"
+        >
+          <Users size={15} />
+          {!collapsed && <span className="font-medium">Characters</span>}
         </button>
       </div>
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -47,6 +47,8 @@ export interface Character {
   systemPrompt: string
   tags: string[]
   description: string
+  avatarUrl?: string
+  notes?: string
   isBuiltIn?: boolean
 }
 


### PR DESCRIPTION
- New Characters page in the sidebar with Library, Create, Transcribe,
  and AI Idea tabs
- Character Transcriber: paste notes, drop in text/markdown/json files,
  attach reference images. Dedicated archivist system prompt extracts
  every key point and produces a structured Markdown character sheet
  plus a rich second-person system prompt
- Character Editor: avatar image upload, notes/lore field, full
  control over emoji, color, tags, description, system prompt
- Character cards and chat surfaces now render uploaded avatars
  alongside the existing emoji fallback (chat header, message
  bubbles, character pill, selector grid)
- Adds avatarUrl and notes to the Character type
- Sidebar gains a Chats / Characters tab switcher and a
  Ctrl+Shift+P shortcut