### PR TITLE
Fix Android launch crash caused by stale jamba package in MainActivity

### DIFF
--- a/android/app/src/main/java/dev/lozt/openstarchat/MainActivity.java
+++ b/android/app/src/main/java/dev/lozt/openstarchat/MainActivity.java
@@ -1,4 +1,4 @@
-package dev.lozt.jamba;
+package dev.lozt.openstarchat;
 
 import com.getcapacitor.BridgeActivity;
 


### PR DESCRIPTION
The rebrand from Jamba to OpenStarChat updated the Gradle namespace and
applicationId to dev.lozt.openstarchat, but MainActivity.java was left
in the dev.lozt.jamba package. Android resolves .MainActivity against
the namespace, so the class was never found and the app crashed immediately
on launch.

https://claude.ai/code/session_01NAjfPnfe7Wz8QytGciMA1a