### PR TITLE
Make sidebar a mobile slide-out, fix ModelPicker on small screens, layer starfield behind UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ export default function App() {
   const [showBookmarks, setShowBookmarks] = useState(false)
   const [isIdle, setIsIdle] = useState(false)
   const [view, setView] = useState<MainView>('chat')
+  const [sidebarOpen, setSidebarOpen] = useState(false)
 
   const activeChatId = useChatStore((s) => s.activeChatId)
   const createChat = useChatStore((s) => s.createChat)
@@ -93,6 +94,8 @@ export default function App() {
         onOpenBookmarks={() => setShowBookmarks(true)}
         view={view}
         onChangeView={setView}
+        sidebarOpen={sidebarOpen}
+        onSidebarOpenChange={setSidebarOpen}
       >
         {view === 'chat' ? (
           <ChatView
@@ -101,9 +104,13 @@ export default function App() {
             onOpenCharacters={() => setShowCharacters(true)}
             onOpenCharactersPage={() => setView('characters')}
             onNeedApiKey={() => setShowSettings(true)}
+            onOpenSidebar={() => setSidebarOpen(true)}
           />
         ) : (
-          <CharactersPage onBackToChat={() => setView('chat')} />
+          <CharactersPage
+            onBackToChat={() => setView('chat')}
+            onOpenSidebar={() => setSidebarOpen(true)}
+          />
         )}
       </AppLayout>
 

--- a/src/components/Starfield.tsx
+++ b/src/components/Starfield.tsx
@@ -204,7 +204,7 @@ function drawAurora(canvas: HTMLCanvasElement): () => void {
 
 // ── Component ────────────────────────────────────────────────────────────────
 
-export function Starfield({ onDismiss, animationType }: StarfieldProps) {
+export function Starfield({ onDismiss: _onDismiss, animationType }: StarfieldProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
 
   useEffect(() => {
@@ -231,18 +231,24 @@ export function Starfield({ onDismiss, animationType }: StarfieldProps) {
       cleanup = drawStarfield(canvas)
     }
 
+    // Mark <body> so global styles can let the starfield show through transparent
+    // app-bg surfaces while idle. Any user input dismisses idle via useIdleTimer,
+    // which unmounts this component and removes the class.
+    document.body.classList.add('is-idle')
+
     return () => {
       cleanup()
       window.removeEventListener('resize', resize)
+      document.body.classList.remove('is-idle')
     }
   }, [animationType])
 
   return (
     <canvas
       ref={canvasRef}
-      className="fixed inset-0 z-30"
-      style={{ cursor: 'pointer', background: '#000' }}
-      onClick={onDismiss}
+      aria-hidden
+      className="fixed inset-0 z-0 pointer-events-none"
+      style={{ background: '#000' }}
     />
   )
 }

--- a/src/components/characters/CharactersPage.tsx
+++ b/src/components/characters/CharactersPage.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react'
 import {
   Users, Plus, ScrollText, Sparkles, Search, MessageSquarePlus, Edit2, Trash2,
-  Lock, Check, X, ArrowLeft, Wand2,
+  Lock, Check, X, ArrowLeft, Wand2, Menu,
 } from 'lucide-react'
 import clsx from 'clsx'
 import { useChatStore } from '../../store/chatStore'
@@ -15,9 +15,10 @@ type Tab = 'library' | 'create' | 'transcribe' | 'idea'
 
 interface CharactersPageProps {
   onBackToChat: () => void
+  onOpenSidebar: () => void
 }
 
-export function CharactersPage({ onBackToChat }: CharactersPageProps) {
+export function CharactersPage({ onBackToChat, onOpenSidebar }: CharactersPageProps) {
   const characters = useChatStore((s) => s.characters)
   const activeChatId = useChatStore((s) => s.activeChatId)
   const chats = useChatStore((s) => s.chats)
@@ -105,14 +106,22 @@ export function CharactersPage({ onBackToChat }: CharactersPageProps) {
       >
         <div className="flex items-center gap-2 min-w-0">
           <button
+            onClick={onOpenSidebar}
+            className="btn-ghost p-1.5 rounded-lg shrink-0 md:hidden"
+            title="Open menu"
+            aria-label="Open menu"
+          >
+            <Menu size={18} />
+          </button>
+          <button
             onClick={onBackToChat}
-            className="btn-ghost p-1.5 rounded-lg flex items-center gap-1.5"
+            className="btn-ghost p-1.5 rounded-lg flex items-center gap-1.5 shrink-0"
             title="Back to chat"
           >
             <ArrowLeft size={15} />
           </button>
-          <Users size={16} style={{ color: 'var(--accent)' }} />
-          <h2 className="font-bold text-base">Characters</h2>
+          <Users size={16} style={{ color: 'var(--accent)' }} className="shrink-0" />
+          <h2 className="font-bold text-base truncate">Characters</h2>
           <span className="text-xs text-muted hidden sm:inline">
             ({characters.length})
           </span>

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
-import { BookOpen, Users, Sparkles } from 'lucide-react'
+import { BookOpen, Users, Sparkles, Menu } from 'lucide-react'
 import { useChatStore } from '../../store/chatStore'
 import { useSettingsStore } from '../../store/settingsStore'
 import { useStreamingChat } from '../../hooks/useStreamingChat'
@@ -13,6 +13,7 @@ interface ChatViewProps {
   onOpenCharacters: () => void
   onOpenCharactersPage: () => void
   onNeedApiKey: () => void
+  onOpenSidebar: () => void
 }
 
 export function ChatView({
@@ -21,6 +22,7 @@ export function ChatView({
   onOpenCharacters,
   onOpenCharactersPage,
   onNeedApiKey,
+  onOpenSidebar,
 }: ChatViewProps) {
   const chats = useChatStore((s) => s.chats)
   const activeChatId = useChatStore((s) => s.activeChatId)
@@ -83,7 +85,21 @@ export function ChatView({
   // Empty state
   if (!activeChat) {
     return (
-      <div className="flex-1 flex flex-col items-center justify-center gap-6 p-8 app-bg">
+      <div className="flex-1 flex flex-col min-h-0 app-bg">
+        <header
+          className="md:hidden flex items-center px-3 py-2 border-b border-subtle shrink-0"
+          style={{ background: 'var(--bg-secondary)' }}
+        >
+          <button
+            onClick={onOpenSidebar}
+            className="btn-ghost p-1.5 rounded-lg"
+            title="Open menu"
+            aria-label="Open menu"
+          >
+            <Menu size={18} />
+          </button>
+        </header>
+        <div className="flex-1 flex flex-col items-center justify-center gap-6 p-8">
         <div className="text-center">
           <h1 className="text-3xl font-bold mb-2 accent-text">OpenStarChat</h1>
           <p className="text-muted text-sm">Your OpenRouter chat interface</p>
@@ -111,6 +127,7 @@ export function ChatView({
             onClick={onOpenPrompts}
           />
         </div>
+        </div>
       </div>
     )
   }
@@ -125,6 +142,14 @@ export function ChatView({
         style={{ background: 'var(--bg-secondary)' }}
       >
         <div className="flex items-center gap-2 min-w-0">
+          <button
+            onClick={onOpenSidebar}
+            className="btn-ghost p-1.5 rounded-lg shrink-0 md:hidden"
+            title="Open menu"
+            aria-label="Open menu"
+          >
+            <Menu size={18} />
+          </button>
           {character && (
             character.avatarUrl ? (
               <img

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -7,6 +7,8 @@ interface AppLayoutProps {
   onOpenBookmarks: () => void
   view: 'chat' | 'characters'
   onChangeView: (v: 'chat' | 'characters') => void
+  sidebarOpen: boolean
+  onSidebarOpenChange: (open: boolean) => void
 }
 
 export function AppLayout({
@@ -15,19 +17,43 @@ export function AppLayout({
   onOpenBookmarks,
   view,
   onChangeView,
+  sidebarOpen,
+  onSidebarOpenChange,
 }: AppLayoutProps) {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
 
+  function closeMobile() {
+    onSidebarOpenChange(false)
+  }
+
+  function handleChangeView(v: 'chat' | 'characters') {
+    onChangeView(v)
+    closeMobile()
+  }
+
   return (
-    <div className="flex h-full overflow-hidden app-bg">
+    <div className="relative z-10 flex h-full overflow-hidden app-bg">
+      {/* Mobile backdrop — covers main content while sidebar is open */}
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 z-30 md:hidden fade-in"
+          style={{ background: 'rgba(0,0,0,0.45)', backdropFilter: 'blur(2px)' }}
+          onClick={closeMobile}
+          aria-hidden
+        />
+      )}
+
       <Sidebar
         collapsed={sidebarCollapsed}
         onToggle={() => setSidebarCollapsed((v) => !v)}
-        onOpenSettings={onOpenSettings}
-        onOpenBookmarks={onOpenBookmarks}
+        onOpenSettings={() => { onOpenSettings(); closeMobile() }}
+        onOpenBookmarks={() => { onOpenBookmarks(); closeMobile() }}
         view={view}
-        onChangeView={onChangeView}
+        onChangeView={handleChangeView}
+        mobileOpen={sidebarOpen}
+        onMobileClose={closeMobile}
       />
+
       <main className="flex-1 flex flex-col min-w-0 overflow-hidden">
         {children}
       </main>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,7 +1,7 @@
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import {
   MessageSquare, Plus, Trash2, Settings, ChevronLeft, ChevronRight,
-  Download, Upload, Pin, PinOff, Search, Bookmark, ChevronDown, Users,
+  Download, Upload, Pin, PinOff, Search, Bookmark, ChevronDown, Users, X,
 } from 'lucide-react'
 import { useChatStore } from '../../store/chatStore'
 import { useSettingsStore } from '../../store/settingsStore'
@@ -15,10 +15,15 @@ interface SidebarProps {
   onOpenBookmarks: () => void
   view: 'chat' | 'characters'
   onChangeView: (v: 'chat' | 'characters') => void
+  /** Whether the mobile overlay is open. Ignored on >= md screens. */
+  mobileOpen?: boolean
+  /** Close handler for the mobile overlay. */
+  onMobileClose?: () => void
 }
 
 export function Sidebar({
   collapsed, onToggle, onOpenSettings, onOpenBookmarks, view, onChangeView,
+  mobileOpen = false, onMobileClose,
 }: SidebarProps) {
   const chats = useChatStore((s) => s.chats)
   const activeChatId = useChatStore((s) => s.activeChatId)
@@ -35,7 +40,21 @@ export function Sidebar({
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   const [showExportMenu, setShowExportMenu] = useState(false)
+  const [isMobile, setIsMobile] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // Collapsed icon-only mode only applies on desktop. On mobile, the overlay
+  // always shows full labels regardless of the `collapsed` setting.
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return
+    const mq = window.matchMedia('(max-width: 767px)')
+    const update = () => setIsMobile(mq.matches)
+    update()
+    mq.addEventListener('change', update)
+    return () => mq.removeEventListener('change', update)
+  }, [])
+
+  const effectiveCollapsed = collapsed && !isMobile
 
   function handleNewChat() {
     createChat(defaultModelId)
@@ -98,14 +117,14 @@ export function Sidebar({
           isActive ? 'bg-accent text-white' : 'hover:bg-tertiary'
         )}
         style={isActive ? { background: 'var(--accent)', color: 'white' } : undefined}
-        title={collapsed ? chat.title : undefined}
+        title={effectiveCollapsed ? chat.title : undefined}
       >
         {chat.pinned ? (
           <Pin size={13} className="shrink-0" style={{ color: isActive ? 'white' : 'var(--accent)' }} />
         ) : (
           <MessageSquare size={14} className="shrink-0" style={{ color: isActive ? 'white' : 'var(--text-secondary)' }} />
         )}
-        {!collapsed && (
+        {!effectiveCollapsed && (
           <>
             <span className="truncate flex-1 min-w-0">{chat.title}</span>
             <div className="shrink-0 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
@@ -138,19 +157,33 @@ export function Sidebar({
   return (
     <aside
       className={clsx(
-        'flex flex-col h-full border-r border-subtle transition-all duration-200',
-        collapsed ? 'w-12' : 'w-64'
+        'sidebar-aside flex flex-col h-full border-r border-subtle',
+        // Mobile: off-canvas overlay
+        'fixed left-0 top-0 bottom-0 z-40 w-72 max-w-[85vw] transition-transform duration-200',
+        mobileOpen ? 'translate-x-0 shadow-2xl' : '-translate-x-full',
+        // Desktop: docked, override fixed positioning + translation
+        'md:static md:translate-x-0 md:shadow-none md:max-w-none md:transition-[width]',
+        collapsed ? 'md:w-12' : 'md:w-64',
       )}
-      style={{ background: 'var(--bg-secondary)' }}
     >
       {/* Header */}
       <div className="flex items-center justify-between p-3 border-b border-subtle shrink-0">
-        {!collapsed && (
-          <span className="font-bold text-lg tracking-tight accent-text">OpenStarChat</span>
+        {!effectiveCollapsed && (
+          <span className="font-bold text-lg tracking-tight accent-text truncate">OpenStarChat</span>
         )}
+        {/* Mobile-only close button */}
+        <button
+          onClick={onMobileClose}
+          className="btn-ghost p-1.5 rounded-md md:hidden"
+          title="Close sidebar"
+          aria-label="Close sidebar"
+        >
+          <X size={16} />
+        </button>
+        {/* Desktop-only collapse toggle */}
         <button
           onClick={onToggle}
-          className={clsx('btn-ghost p-1.5 rounded-md', collapsed && 'mx-auto')}
+          className={clsx('btn-ghost p-1.5 rounded-md hidden md:inline-flex', collapsed && 'mx-auto')}
           title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
         >
           {collapsed ? <ChevronRight size={16} /> : <ChevronLeft size={16} />}
@@ -163,12 +196,12 @@ export function Sidebar({
           onClick={handleNewChat}
           className={clsx(
             'btn-primary flex items-center gap-2 w-full justify-center text-sm',
-            collapsed ? 'p-2' : 'px-3 py-2'
+            effectiveCollapsed ? 'p-2' : 'px-3 py-2'
           )}
           title="New Chat (Ctrl+N)"
         >
           <Plus size={16} />
-          {!collapsed && <span>New Chat</span>}
+          {!effectiveCollapsed && <span>New Chat</span>}
         </button>
       </div>
 
@@ -178,7 +211,7 @@ export function Sidebar({
           onClick={() => onChangeView('chat')}
           className={clsx(
             'flex items-center gap-2 w-full text-sm rounded-lg px-2 py-1.5 transition-colors',
-            collapsed ? 'justify-center' : 'justify-start',
+            effectiveCollapsed ? 'justify-center' : 'justify-start',
             view === 'chat' ? 'tab-active' : 'btn-ghost'
           )}
           style={view === 'chat'
@@ -187,13 +220,13 @@ export function Sidebar({
           title="Chats"
         >
           <MessageSquare size={15} />
-          {!collapsed && <span className="font-medium">Chats</span>}
+          {!effectiveCollapsed && <span className="font-medium">Chats</span>}
         </button>
         <button
           onClick={() => onChangeView('characters')}
           className={clsx(
             'flex items-center gap-2 w-full text-sm rounded-lg px-2 py-1.5 transition-colors',
-            collapsed ? 'justify-center' : 'justify-start',
+            effectiveCollapsed ? 'justify-center' : 'justify-start',
             view === 'characters' ? '' : 'btn-ghost'
           )}
           style={view === 'characters'
@@ -202,12 +235,12 @@ export function Sidebar({
           title="Characters (Ctrl+Shift+P)"
         >
           <Users size={15} />
-          {!collapsed && <span className="font-medium">Characters</span>}
+          {!effectiveCollapsed && <span className="font-medium">Characters</span>}
         </button>
       </div>
 
       {/* Search */}
-      {!collapsed && (
+      {!effectiveCollapsed && (
         <div className="px-2 pb-1 shrink-0">
           <div
             className="flex items-center gap-2 px-2.5 py-1.5 rounded-lg border border-subtle"
@@ -228,7 +261,7 @@ export function Sidebar({
 
       {/* Chat list */}
       <div className="flex-1 overflow-y-auto min-h-0 py-1 px-1">
-        {sorted.length === 0 && !collapsed && (
+        {sorted.length === 0 && !effectiveCollapsed && (
           <p className="text-center text-muted text-xs px-4 py-8">
             {searchQuery ? 'No matching chats.' : 'No chats yet. Start a new one!'}
           </p>
@@ -243,29 +276,29 @@ export function Sidebar({
         {/* Bookmarks */}
         <button
           onClick={onOpenBookmarks}
-          className={clsx('btn-ghost flex items-center gap-2 w-full text-sm', collapsed ? 'justify-center' : '')}
+          className={clsx('btn-ghost flex items-center gap-2 w-full text-sm', effectiveCollapsed ? 'justify-center' : '')}
           title="Bookmarked messages"
         >
           <Bookmark size={15} />
-          {!collapsed && <span>Bookmarks</span>}
+          {!effectiveCollapsed && <span>Bookmarks</span>}
         </button>
 
         {/* Export with submenu */}
         <div className="relative">
           <button
             onClick={() => setShowExportMenu((v) => !v)}
-            className={clsx('btn-ghost flex items-center gap-2 w-full text-sm', collapsed ? 'justify-center' : '')}
+            className={clsx('btn-ghost flex items-center gap-2 w-full text-sm', effectiveCollapsed ? 'justify-center' : '')}
             title="Export chats"
           >
             <Download size={15} />
-            {!collapsed && (
+            {!effectiveCollapsed && (
               <>
                 <span className="flex-1 text-left">Export Chats</span>
                 <ChevronDown size={12} className={clsx('transition-transform', showExportMenu && 'rotate-180')} />
               </>
             )}
           </button>
-          {showExportMenu && !collapsed && (
+          {showExportMenu && !effectiveCollapsed && (
             <div
               className="absolute bottom-full left-0 mb-1 w-full rounded-lg border border-subtle shadow-lg overflow-hidden z-10"
               style={{ background: 'var(--bg-secondary)' }}
@@ -290,11 +323,11 @@ export function Sidebar({
         {/* Import */}
         <button
           onClick={() => fileInputRef.current?.click()}
-          className={clsx('btn-ghost flex items-center gap-2 w-full text-sm', collapsed ? 'justify-center' : '')}
+          className={clsx('btn-ghost flex items-center gap-2 w-full text-sm', effectiveCollapsed ? 'justify-center' : '')}
           title="Import chats from JSON"
         >
           <Upload size={15} />
-          {!collapsed && <span>Import Chats</span>}
+          {!effectiveCollapsed && <span>Import Chats</span>}
         </button>
         <input
           ref={fileInputRef}
@@ -307,11 +340,11 @@ export function Sidebar({
         {/* Settings */}
         <button
           onClick={onOpenSettings}
-          className={clsx('btn-ghost flex items-center gap-2 w-full text-sm', collapsed ? 'justify-center' : '')}
+          className={clsx('btn-ghost flex items-center gap-2 w-full text-sm', effectiveCollapsed ? 'justify-center' : '')}
           title="Settings"
         >
           <Settings size={15} />
-          {!collapsed && <span>Settings</span>}
+          {!effectiveCollapsed && <span>Settings</span>}
         </button>
       </div>
     </aside>

--- a/src/components/models/ModelPicker.tsx
+++ b/src/components/models/ModelPicker.tsx
@@ -128,31 +128,31 @@ export function ModelPicker({ onClose, chatId, onSelectModel, currentModelIdOver
 
   return (
     <div
-      className="fixed inset-0 z-40 flex items-center justify-center p-4"
+      className="fixed inset-0 z-40 flex items-stretch sm:items-center justify-center p-0 sm:p-4"
       style={{ background: 'rgba(0,0,0,0.6)' }}
       onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
     >
       <div
-        className="w-full max-w-2xl max-h-[85vh] rounded-2xl flex flex-col shadow-2xl fade-in"
+        className="w-full max-w-2xl flex flex-col shadow-2xl fade-in rounded-none sm:rounded-2xl max-h-[100dvh] sm:max-h-[85svh]"
         style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border)' }}
       >
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 border-b border-subtle shrink-0">
-          <h2 className="font-bold text-base">{title ?? 'Select Model'}</h2>
-          <div className="flex items-center gap-2">
+          <h2 className="font-bold text-base truncate">{title ?? 'Select Model'}</h2>
+          <div className="flex items-center gap-2 shrink-0">
             <button onClick={loadModels} className="btn-ghost p-1.5 rounded-lg" title="Refresh models">
               <RefreshCw size={15} className={isLoading ? 'animate-spin' : ''} />
             </button>
-            <button onClick={onClose} className="btn-ghost p-1.5 rounded-lg">
+            <button onClick={onClose} className="btn-ghost p-1.5 rounded-lg" aria-label="Close">
               <X size={16} />
             </button>
           </div>
         </div>
 
         {/* Search + sort row */}
-        <div className="flex items-center gap-2 px-4 py-2 border-b border-subtle shrink-0">
+        <div className="flex flex-col sm:flex-row sm:items-center gap-2 px-3 sm:px-4 py-2 border-b border-subtle shrink-0">
           <div
-            className="flex items-center gap-2 flex-1 rounded-lg px-3 py-2"
+            className="flex items-center gap-2 flex-1 min-w-0 rounded-lg px-3 py-2"
             style={{ background: 'var(--bg-tertiary)' }}
           >
             <Search size={14} className="text-muted shrink-0" />
@@ -161,15 +161,14 @@ export function ModelPicker({ onClose, chatId, onSelectModel, currentModelIdOver
               value={localQuery}
               onChange={handleSearchChange}
               placeholder="Search models…"
-              className="flex-1 bg-transparent outline-none text-sm"
+              className="flex-1 min-w-0 bg-transparent outline-none text-sm"
               style={{ color: 'var(--text-primary)' }}
             />
           </div>
           <select
             value={sortKey}
             onChange={(e) => setSortKey(e.target.value as ModelSortKey)}
-            className="input-field text-xs py-2 w-auto"
-            style={{ width: 'auto', minWidth: '9rem' }}
+            className="input-field text-xs py-2 w-full sm:w-auto sm:min-w-[9rem]"
           >
             {SORT_OPTIONS.map((o) => (
               <option key={o.key} value={o.key}>{o.label}</option>

--- a/src/index.css
+++ b/src/index.css
@@ -219,5 +219,28 @@ body {
 
 .fade-in { animation: fadeIn 0.15s ease-out; }
 
+/* Idle state: let the starfield canvas (z-0, behind UI) show through the app
+   background. Solid panels (sidebar, chat header, input bar, modals) keep their
+   own bg-secondary/tertiary colors and remain opaque. */
+body.is-idle .app-bg {
+  background-color: transparent !important;
+}
+body.is-idle {
+  background-color: transparent;
+}
+
+/* Sidebar overlay: slightly translucent + blurred on mobile so users can see
+   that something is layered above the content. Solid on desktop. */
+.sidebar-aside {
+  background-color: var(--bg-secondary);
+}
+@media (max-width: 767px) {
+  .sidebar-aside {
+    background-color: color-mix(in srgb, var(--bg-secondary) 92%, transparent);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+  }
+}
+
 /* Code block overrides for dark syntax themes */
 pre { border-radius: 0.5rem; overflow: hidden; }


### PR DESCRIPTION
The mobile layout previously shrank the main content area whenever the sidebar
was visible, scrunching cards/buttons and clipping text in the right panel.
This converts the sidebar into an off-canvas overlay below md breakpoint —
slides in over content with a translucent blurred panel and a dim backdrop —
while keeping the docked, collapsible behavior on desktop. ChatView and
CharactersPage gained a hamburger button to open it.

The model picker was unusable when the on-screen keyboard appeared: it sized
to 85vh which ignored the keyboard, and the search/sort row overflowed
horizontally on narrow screens. The dialog now stretches edge-to-edge on
mobile, caps at 100dvh so it respects the keyboard, and stacks search above
sort below the sm breakpoint.

The starfield idle animation took over the entire screen. Now it renders
behind the UI at z-0 with pointer-events disabled; while idle a body class
flips .app-bg surfaces to transparent so stars show through the chat
background, leaving solid panels (sidebar, chat header, input bar, bubbles)
intact.

https://claude.ai/code/session_014Pvsc1ciurbpRbCaee8SbH