### PR TITLE
Fix mobile layout: sidebar overlay, ModelPicker, starfield, and zero-models bug

### DIFF
--- a/src/api/openrouter.ts
+++ b/src/api/openrouter.ts
@@ -12,15 +12,24 @@ function headers(apiKey: string): Record<string, string> {
 }
 
 export async function fetchModels(apiKey: string): Promise<Model[]> {
-  const res = await fetch(`${BASE_URL}/models`, {
-    headers: headers(apiKey),
-  })
+  // OpenRouter's /models endpoint is public; auth is sent if available so that
+  // any private/preview models the user has access to also show up.
+  const reqHeaders: Record<string, string> = {
+    'HTTP-Referer': window.location.origin,
+    'X-Title': 'OpenStarChat',
+  }
+  if (apiKey) reqHeaders.Authorization = `Bearer ${apiKey}`
+
+  const res = await fetch(`${BASE_URL}/models`, { headers: reqHeaders })
   if (!res.ok) {
     const text = await res.text().catch(() => '')
     throw new Error(`Failed to fetch models: ${res.status} ${text}`)
   }
-  const data = await res.json()
-  return (data.data as Model[]) ?? []
+  const payload = await res.json().catch(() => null) as { data?: unknown } | null
+  if (!payload || !Array.isArray(payload.data)) {
+    throw new Error('Unexpected response from /models — no `data` array.')
+  }
+  return payload.data as Model[]
 }
 
 export type ApiMessagePart =

--- a/src/components/models/ModelPicker.tsx
+++ b/src/components/models/ModelPicker.tsx
@@ -48,7 +48,6 @@ export function ModelPicker({ onClose, chatId, onSelectModel, currentModelIdOver
   const models = useModelStore((s) => s.models)
   const isLoading = useModelStore((s) => s.isLoading)
   const error = useModelStore((s) => s.error)
-  const hasFetched = useModelStore((s) => s.hasFetched)
   const searchQuery = useModelStore((s) => s.searchQuery)
   const sortKey = useModelStore((s) => s.sortKey)
   const category = useModelStore((s) => s.category)
@@ -78,13 +77,15 @@ export function ModelPicker({ onClose, chatId, onSelectModel, currentModelIdOver
   const [localQuery, setLocalQuery] = useState(searchQuery)
 
   async function loadModels() {
-    if (!apiKey) { setError('No API key set. Go to Settings.'); return }
     setLoading(true)
     setError(null)
     try {
       const data = await fetchModels(apiKey)
       setModels(data)
       setHasFetched(true)
+      if (data.length === 0) {
+        setError('OpenRouter returned an empty model list.')
+      }
     } catch (e) {
       setError((e as Error).message)
     } finally {
@@ -93,7 +94,10 @@ export function ModelPicker({ onClose, chatId, onSelectModel, currentModelIdOver
   }
 
   useEffect(() => {
-    if (!hasFetched && apiKey) loadModels()
+    // Always (re)fetch when opening the picker if the store is empty — the
+    // previous gate was `!hasFetched`, which left the user stranded if a prior
+    // fetch returned an unexpected payload.
+    if (models.length === 0 && !isLoading) loadModels()
     const focusTimer = setTimeout(() => searchRef.current?.focus(), 50)
     return () => clearTimeout(focusTimer)
     // Run once on mount: fetch models and focus the search box.


### PR DESCRIPTION
## Summary

- **Sidebar is now an off-canvas slide-out on mobile** with a translucent blurred panel and a dim backdrop. Below `md` it overlays the content instead of shrinking it (no more scrunched cards / clipped buttons in the right panel). Desktop keeps the docked + collapsible behavior.
- **Hamburger menu** added to the `ChatView` and `CharactersPage` headers (visible only on mobile) so the sidebar can actually be summoned again after closing.
- **ModelPicker survives the on-screen keyboard**: the dialog stretches edge-to-edge on small screens, capped at `100dvh` so the keyboard doesn't occlude it, and the search/sort row stacks vertically below `sm` (the "Newest" dropdown was getting clipped).
- **Starfield idle animation only replaces the background now**: canvas rendered at `z-0` with `pointer-events: none`, and a `body.is-idle` class flips `.app-bg` surfaces transparent so stars show through the chat background. Solid panels (sidebar, headers, input bar, bubbles, modals) stay opaque and usable.
- **Fixed the "0 models shown" softlock** in the model picker:
  - `useEffect` was gated on `hasFetched`, so any prior fetch that parsed to an empty list left the store permanently empty until manual refresh.
  - `fetchModels` did `(data.data as Model[]) ?? []` and silently returned `[]` for unexpected payloads — no error surfaced.
  - The `apiKey` gate produced a misleading "No API key set" error even though `/models` is a public endpoint.
  - Now: refetch whenever the store is empty, throw a clear error if the response shape is wrong, and surface a banner if OpenRouter returns zero models.

## Test plan

- [ ] On a phone (< 768 px), tap the new hamburger button — sidebar slides in over content with a dim backdrop.
- [ ] Tap the backdrop or X — sidebar slides out.
- [ ] On desktop (≥ 768 px), the sidebar is still docked and the chevron still toggles the icon-only collapsed mode.
- [ ] Open Select Model on a phone — search/sort stack, dialog fills the screen, model list reachable above the keyboard.
- [ ] Reopen Select Model on a fresh install — models populate; if OpenRouter ever returns empty, banner explains why instead of a silent blank panel.
- [ ] Idle for 15s — starfield appears as a background layer; sidebar / headers / bubbles still look normal on top of it.
- [ ] Touch / move — starfield dismisses.

https://claude.ai/code/session_014Pvsc1ciurbpRbCaee8SbH

---
_Generated by [Claude Code](https://claude.ai/code/session_014Pvsc1ciurbpRbCaee8SbH)_