### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+## Cursor Cloud specific instructions
+
+**Product**: OpenStarChat — a client-side React SPA that wraps the OpenRouter API for AI chat. There is no backend; all state lives in localStorage via Zustand.
+
+**Tech stack**: TypeScript, React 19, Vite 8, Tailwind CSS 3, Zustand 5, npm.
+
+### Running the dev server
+
+```
+npm run dev -- --host 0.0.0.0
+```
+
+Starts on `http://localhost:5173/`. Hot-module reloading works out of the box.
+
+### Build
+
+```
+npm run build
+```
+
+Runs `tsc -b && vite build`; output goes to `dist/`.
+
+### Lint / Tests
+
+- No ESLint config or test framework is currently configured in this repo. The only compile-time check is the TypeScript build (`tsc -b`).
+- There are no automated test scripts (`npm test` is not defined).
+
+### Key caveats
+
+- The app requires an **OpenRouter API key** at runtime (entered in the Settings modal, stored in localStorage). Without a key, you can explore the full UI but cannot send chat messages.
+- The Android/Capacitor build (`android/` directory) requires Java 21 + Android SDK and is not needed for web development.
+- No `.env` file is needed; all configuration happens in-browser through the Settings modal.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development instructions for future cloud agents working in this repo.

## What's included

- Product overview (client-side React SPA wrapping OpenRouter API)
- Tech stack reference (TypeScript, React 19, Vite 8, Tailwind CSS 3, Zustand 5, npm)
- Dev server, build, and lint/test commands
- Key caveats (API key requirement, no backend, Android build optional)

## Environment verification

The dev environment was fully set up and verified:

- **npm install** — 307 packages, 0 vulnerabilities
- **tsc -b** — TypeScript compiles cleanly
- **npm run build** — Production build succeeds
- **npm run dev** — Vite dev server starts on port 5173

### Demo

[openstarchat_demo_walkthrough.mp4](https://cursor.com/agents/bc-6b07f36b-2f1b-4d20-8ca5-139378d5a210/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopenstarchat_demo_walkthrough.mp4)

The walkthrough shows the main chat interface, Settings modal, Characters page, Model picker (367+ models), and interactive chat input — all working correctly.

[Main chat interface](https://cursor.com/agents/bc-6b07f36b-2f1b-4d20-8ca5-139378d5a210/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmain_interface.webp)
[Settings modal](https://cursor.com/agents/bc-6b07f36b-2f1b-4d20-8ca5-139378d5a210/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_modal.webp)
[Model picker with 367+ models](https://cursor.com/agents/bc-6b07f36b-2f1b-4d20-8ca5-139378d5a210/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmodel_picker.webp)
[Chat input test](https://cursor.com/agents/bc-6b07f36b-2f1b-4d20-8ca5-139378d5a210/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchat_input_test.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b07f36b-2f1b-4d20-8ca5-139378d5a210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b07f36b-2f1b-4d20-8ca5-139378d5a210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

