### PR TITLE
fix: Gradle build failure — Groovy variable name collision with DSL methods

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -3,10 +3,10 @@ apply plugin: 'com.android.application'
 def versionCodeFromEnv = System.getenv("OPENSTARCHAT_VERSION_CODE")
 def computedVersionCode = versionCodeFromEnv ? versionCodeFromEnv.toInteger() : 1
 
-def keystoreFile = System.getenv("KEYSTORE_FILE")
-def keystorePassword = System.getenv("KEYSTORE_PASSWORD") ?: "openstarchat"
-def keyAlias = System.getenv("KEY_ALIAS") ?: "openstarchat"
-def keyPassword = System.getenv("KEY_PASSWORD") ?: "openstarchat"
+def keystoreFilePath = System.getenv("KEYSTORE_FILE")
+def ksPassword = System.getenv("KEYSTORE_PASSWORD") ?: "openstarchat"
+def ksAlias = System.getenv("KEY_ALIAS") ?: "openstarchat"
+def ksKeyPassword = System.getenv("KEY_PASSWORD") ?: "openstarchat"
 
 android {
     namespace = "dev.lozt.openstarchat"
@@ -27,11 +27,11 @@ android {
 
     signingConfigs {
         release {
-            if (keystoreFile && file(keystoreFile).exists()) {
-                storeFile file(keystoreFile)
-                storePassword keystorePassword
-                keyAlias keyAlias
-                keyPassword keyPassword
+            if (keystoreFilePath && file(keystoreFilePath).exists()) {
+                storeFile = file(keystoreFilePath)
+                storePassword = ksPassword
+                keyAlias = ksAlias
+                keyPassword = ksKeyPassword
             }
         }
     }
@@ -40,7 +40,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            if (keystoreFile && file(keystoreFile).exists()) {
+            if (keystoreFilePath && file(keystoreFilePath).exists()) {
                 signingConfig signingConfigs.release
             }
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The CI APK build is failing with:

```
No signature of method: java.lang.String.call() is applicable
for argument types: (String) values: [openstarchat]
```

at `android/app/build.gradle` line 33.

## Root Cause

A classic Groovy DSL name collision. The local variables `keyAlias` and `keyPassword` shared their names with Gradle's `signingConfig` DSL setter methods. When Groovy encountered:

```groovy
keyAlias keyAlias
```

It interpreted this as: "call the String stored in variable `keyAlias` as a method, passing the value of `keyAlias` as an argument" — hence `java.lang.String.call()`.

## Fix

1. **Renamed local variables** to avoid collisions:
   - `keystoreFile` → `keystoreFilePath`
   - `keystorePassword` → `ksPassword`
   - `keyAlias` → `ksAlias`
   - `keyPassword` → `ksKeyPassword`

2. **Explicit `=` assignment** instead of Groovy method-call style:
   ```groovy
   storeFile = file(keystoreFilePath)
   storePassword = ksPassword
   keyAlias = ksAlias
   keyPassword = ksKeyPassword
   ```

The `=` syntax is unambiguous to Groovy and won't be misinterpreted as a method invocation regardless of local variable names.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46ad14ab-03c8-40b0-b019-40cb6411c718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46ad14ab-03c8-40b0-b019-40cb6411c718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

