### PR TITLE
README refresh, markdown input, tools/TTS/usage, multi-attach

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,90 @@
 # OpenStarChat
-A wrapper for OpenRouter with a starry idle animation!
+
+A **client-side React** chat app for **[OpenRouter](https://openrouter.ai/)** (and optional free OpenAI-compatible providers). There is **no backend**: chats, characters, prompts, and settings live in **localStorage** via Zustand.
+
+## Quick start
+
+```bash
+npm install
+npm run dev -- --host 0.0.0.0
+```
+
+Open the URL Vite prints (default `http://localhost:5173/`). Add your **OpenRouter API key** in **Settings** (stored only in the browser). Without a key you can still browse the UI if a **free provider** is enabled in Settings.
+
+```bash
+npm run build
+```
+
+Runs `tsc -b && vite build`; output in `dist/`.
+
+## Features
+
+### Chat & models
+
+- **OpenRouter** streaming chat with **cancel**, **regenerate**, **edit & resend**, and **branch from message**.
+- **Model picker** with search, categories, favorites, recents, sorting, and refresh.
+- **Per-chat temperature & max tokens** (sent with streaming requests).
+- **Compare models** side-by-side (same prompt to multiple models).
+- **Optional free LLM** path: Pollinations.ai or any **OpenAI-compatible** base URL when no OpenRouter key is set.
+
+### Messages & input
+
+- **Markdown** for assistant replies (GFM, code highlighting).
+- **Markdown for user bubbles** and a **live Markdown underlay** in the composer (type `*italic*`, `` `code` ``, etc.).
+- **Multi-image** user turns (several images + text in one message).
+- **Attachments**: images, **PDF text extraction** (client-side via `pdfjs-dist`), and common **text files** append as context blocks.
+- **Web Speech** microphone input where the browser supports it.
+- **Predictive text** (optional): ghost completion; **Tab** to accept.
+- **Per-chat drafts** persisted in localStorage.
+
+### “Power user” API options (per chat, under the sliders panel)
+
+- **Built-in tools** (time, random int) plus optional **extra tools JSON** merged into the OpenRouter request. Only built-in tool **names** are executed locally; unknown tools return an error JSON to the model.
+- **Structured JSON**: optional **JSON Schema** text → `response_format` for models that support it.
+- **Reasoning stream**: when the provider sends reasoning deltas, a collapsible **Thinking** block is filled.
+- **Tool-call loop**: if the model finishes with `tool_calls`, the app runs built-in tools, appends `tool` messages, and **continues** the conversation (depth-limited).
+
+### Characters & prompts
+
+- **Characters** with colors, emoji, optional avatar, system prompt, tags, notes; **AI Character Builder** and **Transcriber** (including vision for reference images).
+- **Prompt library** with built-ins and custom prompts.
+
+### Organization & data
+
+- **Pinned chats**, **folders**, **tags**, sidebar **search** (titles + message text).
+- **Bookmarks** on individual messages.
+- **Memory snippets** (global “always remember” lines injected into the system stack).
+- **Export / import**: full backup JSON, chats-only JSON, Markdown, plain text.
+- **Usage panel** (sidebar **Usage** or **Ctrl/Cmd+U**): rough **assistant token** totals and **estimated spend** from cached model pricing (refresh models in the picker for best accuracy).
+
+### Titles & speech
+
+- **AI chat titles** (optional in Settings): after the first meaningful assistant reply, a small model suggests a short title instead of truncating the first user line.
+- **Read aloud** on assistant bubbles: **browser `speechSynthesis`** or optional **ElevenLabs** (API key + voice id; falls back to browser if the request fails, e.g. CORS).
+
+### Look & feel
+
+- **Themes**: dark, AMOLED, light, Dracula, Nord, cyberpunk, solarized, and **custom** color pickers.
+- **Idle animation** (starfield / shooting stars / aurora / random) after inactivity; click to dismiss.
+- **Android / Capacitor** project in-repo (Java 21 + SDK for native builds; not required for web).
+
+## Keyboard shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| **Ctrl/Cmd+K** | Model picker |
+| **Ctrl/Cmd+N** | New chat (needs key or free provider) |
+| **Ctrl/Cmd+/** | Prompt library |
+| **Ctrl/Cmd+B** | Bookmarks |
+| **Ctrl/Cmd+U** | Usage estimates |
+| **Ctrl/Cmd+,** | Settings |
+| **Ctrl/Cmd+Shift+P** | Toggle Characters page |
+| **Escape** | Close modals |
+
+## Tech stack
+
+TypeScript, **React 19**, **Vite 8**, **Tailwind CSS 3**, **Zustand 5**, `react-markdown`, `remark-gfm`, `remark-breaks`, `react-syntax-highlighter`, **pdfjs-dist** (lazy), optional **Capacitor 8** for Android.
+
+## License
+
+See repository license (if any).

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,12 @@
         "@capacitor/core": "^8.3.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.12.0",
+        "pdfjs-dist": "^4.10.38",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-markdown": "^10.1.0",
         "react-syntax-highlighter": "^16.1.1",
+        "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "zustand": "^5.0.12"
       },
@@ -326,6 +328,256 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -2485,6 +2737,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -3356,6 +3622,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/pdfjs-dist": {
+      "version": "4.10.38",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz",
+      "integrity": "sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.65"
+      }
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -3760,6 +4038,21 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {

--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
     "@capacitor/core": "^8.3.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.12.0",
+    "pdfjs-dist": "^4.10.38",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^16.1.1",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "zustand": "^5.0.12"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { CharacterSelector } from './components/characters/CharacterSelector'
 import { CharactersPage } from './components/characters/CharactersPage'
 import { SettingsModal } from './components/settings/SettingsModal'
 import { BookmarksPanel } from './components/bookmarks/BookmarksPanel'
+import { UsagePanel } from './components/usage/UsagePanel'
 import { CompareView } from './components/chat/CompareView'
 import type { CompareViewHandle } from './components/chat/CompareView'
 import { Starfield } from './components/Starfield'
@@ -22,6 +23,7 @@ export default function App() {
   const [showPrompts, setShowPrompts] = useState(false)
   const [showCharacters, setShowCharacters] = useState(false)
   const [showBookmarks, setShowBookmarks] = useState(false)
+  const [showUsage, setShowUsage] = useState(false)
   const [showCompare, setShowCompare] = useState(false)
   const [comparePickerSlot, setComparePickerSlot] = useState<number | null>(null)
   const compareRef = useRef<CompareViewHandle>(null)
@@ -55,6 +57,7 @@ export default function App() {
         setShowPrompts(false)
         setShowCharacters(false)
         setShowBookmarks(false)
+        setShowUsage(false)
         setIsIdle(false)
         return
       }
@@ -74,6 +77,9 @@ export default function App() {
         } else if (e.key === 'b' || e.key === 'B') {
           e.preventDefault()
           setShowBookmarks((v) => !v)
+        } else if (e.key === 'u' || e.key === 'U') {
+          e.preventDefault()
+          setShowUsage((v) => !v)
         } else if (e.key === ',') {
           e.preventDefault()
           setShowSettings((v) => !v)
@@ -98,6 +104,7 @@ export default function App() {
       <AppLayout
         onOpenSettings={() => setShowSettings(true)}
         onOpenBookmarks={() => setShowBookmarks(true)}
+        onOpenUsage={() => setShowUsage(true)}
         view={view}
         onChangeView={setView}
         sidebarOpen={sidebarOpen}
@@ -141,6 +148,7 @@ export default function App() {
           onNavigateToChat={handleNavigateToChat}
         />
       )}
+      {showUsage && <UsagePanel onClose={() => setShowUsage(false)} />}
 
       {/* Compare View */}
       {showCompare && (

--- a/src/api/builtinTools.ts
+++ b/src/api/builtinTools.ts
@@ -1,0 +1,97 @@
+/** OpenAI-format tool definitions shipped with the app (safe, local execution only). */
+export const BUILTIN_OPENROUTER_TOOLS: unknown[] = [
+  {
+    type: 'function',
+    function: {
+      name: 'get_current_datetime',
+      description:
+        'Returns the current date and time from the user device (ISO-8601 and unix milliseconds).',
+      parameters: { type: 'object', properties: {} },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'get_random_int',
+      description: 'Returns a random integer between min and max (inclusive).',
+      parameters: {
+        type: 'object',
+        properties: {
+          min: { type: 'integer', description: 'Lower bound (inclusive)' },
+          max: { type: 'integer', description: 'Upper bound (inclusive)' },
+        },
+        required: ['min', 'max'],
+      },
+    },
+  },
+]
+
+const SAFE_TOOL_NAMES = new Set(['get_current_datetime', 'get_random_int'])
+
+export function isBuiltinToolName(name: string): boolean {
+  return SAFE_TOOL_NAMES.has(name)
+}
+
+export function runBuiltinTool(name: string, argsJson: string): string {
+  try {
+    if (name === 'get_current_datetime') {
+      return JSON.stringify({
+        iso: new Date().toISOString(),
+        unix_ms: Date.now(),
+      })
+    }
+    if (name === 'get_random_int') {
+      const args = JSON.parse(argsJson || '{}') as { min?: number; max?: number }
+      let min = Number(args.min ?? 0)
+      let max = Number(args.max ?? 10)
+      if (!Number.isFinite(min) || !Number.isFinite(max)) {
+        return JSON.stringify({ error: 'min and max must be numbers' })
+      }
+      if (min > max) [min, max] = [max, min]
+      const lo = Math.ceil(min)
+      const hi = Math.floor(max)
+      if (hi < lo) return JSON.stringify({ error: 'invalid_range' })
+      const value = Math.floor(Math.random() * (hi - lo + 1)) + lo
+      return JSON.stringify({ value })
+    }
+  } catch (e) {
+    return JSON.stringify({ error: String(e) })
+  }
+  return JSON.stringify({ error: `unknown_tool:${name}` })
+}
+
+export type ToolCallAccumulator = Map<
+  number,
+  { id?: string; name: string; arguments: string }
+>
+
+export function mergeToolCallDeltas(
+  acc: ToolCallAccumulator,
+  deltas: Array<{
+    index?: number
+    id?: string
+    function?: { name?: string; arguments?: string }
+  }>,
+): void {
+  for (const d of deltas) {
+    const idx = typeof d.index === 'number' ? d.index : 0
+    const cur = acc.get(idx) ?? { name: '', arguments: '' }
+    if (d.id) cur.id = d.id
+    if (d.function?.name) cur.name += d.function.name
+    if (d.function?.arguments) cur.arguments += d.function.arguments
+    acc.set(idx, cur)
+  }
+}
+
+export function accumulatorToOpenAIToolCalls(
+  acc: ToolCallAccumulator,
+): Array<{ id: string; type: 'function'; function: { name: string; arguments: string } }> {
+  return [...acc.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([, v]) => ({
+      id: v.id ?? `call_${Math.random().toString(36).slice(2, 10)}`,
+      type: 'function' as const,
+      function: { name: v.name, arguments: v.arguments || '{}' },
+    }))
+    .filter((c) => c.function.name)
+}

--- a/src/api/chatTitle.ts
+++ b/src/api/chatTitle.ts
@@ -1,0 +1,26 @@
+import { completeChat } from './openrouter'
+
+export async function generateChatTitle(
+  apiKey: string,
+  userExcerpt: string,
+  assistantExcerpt: string,
+): Promise<string> {
+  const sys =
+    'You name chat conversations. Reply with a short title only: 2-7 words. No quotes. No trailing punctuation.'
+  const u = `User (excerpt): ${userExcerpt.slice(0, 500)}\n\nAssistant (excerpt): ${assistantExcerpt.slice(0, 500)}`
+  const raw = await completeChat({
+    apiKey,
+    modelId: 'openai/gpt-4o-mini',
+    messages: [{ id: 'title', role: 'user', content: u, createdAt: Date.now() }],
+    systemPrompt: sys,
+    temperature: 0.35,
+    maxTokens: 32,
+  })
+  return (
+    raw
+      .replace(/^["'«»]+|["'«»]+$/g, '')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .slice(0, 64) || 'Chat'
+  )
+}

--- a/src/api/elevenlabs.ts
+++ b/src/api/elevenlabs.ts
@@ -1,0 +1,46 @@
+/**
+ * ElevenLabs TTS from the browser. Their API may block some origins via CORS;
+ * if fetch fails, callers should fall back to speechSynthesis.
+ */
+export async function elevenLabsSpeak(opts: {
+  apiKey: string
+  voiceId: string
+  text: string
+}): Promise<void> {
+  const { apiKey, voiceId, text } = opts
+  const trimmed = text.trim()
+  if (!trimmed) return
+
+  const res = await fetch(`https://api.elevenlabs.io/v1/text-to-speech/${encodeURIComponent(voiceId)}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'audio/mpeg',
+      'xi-api-key': apiKey,
+    },
+    body: JSON.stringify({
+      text: trimmed.slice(0, 2500),
+      model_id: 'eleven_turbo_v2_5',
+    }),
+  })
+
+  if (!res.ok) {
+    const errText = await res.text().catch(() => '')
+    throw new Error(`ElevenLabs ${res.status}: ${errText.slice(0, 200)}`)
+  }
+
+  const blob = await res.blob()
+  const url = URL.createObjectURL(blob)
+  const audio = new Audio(url)
+  await new Promise<void>((resolve, reject) => {
+    audio.onended = () => {
+      URL.revokeObjectURL(url)
+      resolve()
+    }
+    audio.onerror = () => {
+      URL.revokeObjectURL(url)
+      reject(new Error('Audio playback failed'))
+    }
+    void audio.play().catch(reject)
+  })
+}

--- a/src/api/freeProvider.ts
+++ b/src/api/freeProvider.ts
@@ -1,18 +1,8 @@
 import type { Message } from '../types'
 import type { ApiMessage } from './openrouter'
-
-function buildApiMessage(msg: Pick<Message, 'role' | 'content' | 'imageUrl'>): ApiMessage {
-  if (msg.role === 'user' && msg.imageUrl) {
-    return {
-      role: 'user',
-      content: [
-        { type: 'image_url', image_url: { url: msg.imageUrl } },
-        { type: 'text', text: msg.content },
-      ],
-    }
-  }
-  return { role: msg.role, content: msg.content }
-}
+import { messageToApiMessage } from './openrouter'
+import { mergeToolCallDeltas, accumulatorToOpenAIToolCalls, type ToolCallAccumulator } from './builtinTools'
+import type { StreamDoneMeta } from './openrouter'
 
 export interface FreeProviderInfo {
   baseUrl: string
@@ -35,10 +25,7 @@ export const POLLINATIONS_MODELS = [
   { id: 'claude-hybridspace', label: 'Claude (via HybridSpace)' },
 ] as const
 
-export function getPollinationsProvider(
-  apiKey: string,
-  model: string,
-): FreeProviderInfo {
+export function getPollinationsProvider(apiKey: string, model: string): FreeProviderInfo {
   return {
     baseUrl: POLLINATIONS_BASE,
     apiKey,
@@ -46,11 +33,7 @@ export function getPollinationsProvider(
   }
 }
 
-export function getCustomProvider(
-  baseUrl: string,
-  apiKey: string,
-  model: string,
-): FreeProviderInfo {
+export function getCustomProvider(baseUrl: string, apiKey: string, model: string): FreeProviderInfo {
   return {
     baseUrl: baseUrl.replace(/\/+$/, ''),
     apiKey,
@@ -60,20 +43,48 @@ export function getCustomProvider(
 
 export type StreamFreeOptions = {
   provider: FreeProviderInfo
-  messages: Pick<Message, 'role' | 'content' | 'imageUrl'>[]
+  messages: Message[]
   systemPrompt?: string
+  temperature?: number
+  maxTokens?: number
+  tools?: unknown[]
+  toolChoice?: unknown
+  responseFormat?: unknown
   onDelta: (delta: string) => void
-  onDone: (tokenCount?: number) => void
+  onReasoningDelta?: (delta: string) => void
+  onDone: (tokenCount?: number, meta?: StreamDoneMeta) => void
   onError: (err: Error) => void
 }
 
+function extractReasoningChunk(delta: Record<string, unknown>): string {
+  const r = delta.reasoning ?? delta.reasoning_content
+  if (typeof r === 'string') return r
+  if (r && typeof r === 'object' && 'text' in r && typeof (r as { text?: unknown }).text === 'string') {
+    return (r as { text: string }).text
+  }
+  return ''
+}
+
 export function streamFree(opts: StreamFreeOptions): () => void {
-  const { provider, messages, systemPrompt, onDelta, onDone, onError } = opts
+  const {
+    provider,
+    messages,
+    systemPrompt,
+    onDelta,
+    onReasoningDelta,
+    onDone,
+    onError,
+    temperature,
+    maxTokens,
+    tools,
+    toolChoice,
+    responseFormat,
+  } = opts
   const controller = new AbortController()
 
   const apiMessages: ApiMessage[] = systemPrompt
-    ? [{ role: 'system', content: systemPrompt }, ...messages.map(buildApiMessage)]
-    : messages.map(buildApiMessage)
+    ? [{ role: 'system', content: systemPrompt }, ...messages.map((m) => messageToApiMessage(m))]
+    : messages.map((m) => messageToApiMessage(m))
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -82,17 +93,26 @@ export function streamFree(opts: StreamFreeOptions): () => void {
     headers['Authorization'] = `Bearer ${provider.apiKey}`
   }
 
+  const body: Record<string, unknown> = {
+    model: provider.model,
+    stream: true,
+    messages: apiMessages,
+    ...(temperature !== undefined ? { temperature } : {}),
+    ...(maxTokens !== undefined ? { max_tokens: maxTokens } : {}),
+  }
+  if (tools?.length) {
+    body.tools = tools
+    body.tool_choice = toolChoice ?? 'auto'
+  }
+  if (responseFormat) body.response_format = responseFormat
+
   ;(async () => {
     let res: Response
     try {
       res = await fetch(`${provider.baseUrl}/v1/chat/completions`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({
-          model: provider.model,
-          stream: true,
-          messages: apiMessages,
-        }),
+        body: JSON.stringify(body),
         signal: controller.signal,
       })
     } catch (err) {
@@ -110,12 +130,15 @@ export function streamFree(opts: StreamFreeOptions): () => void {
     const decoder = new TextDecoder()
     let buffer = ''
     let totalChars = 0
+    let finishReason: string | null | undefined
+    const toolAcc: ToolCallAccumulator = new Map()
 
     try {
       while (true) {
         const { done, value } = await reader.read()
         if (done) {
-          onDone(Math.ceil(totalChars / 4))
+          const toolCalls = toolAcc.size ? accumulatorToOpenAIToolCalls(toolAcc) : null
+          onDone(Math.ceil(totalChars / 4), { finishReason, toolCalls: toolCalls?.length ? toolCalls : null })
           break
         }
 
@@ -128,15 +151,35 @@ export function streamFree(opts: StreamFreeOptions): () => void {
           if (!trimmed.startsWith('data: ')) continue
           const data = trimmed.slice(6)
           if (data === '[DONE]') {
-            onDone(Math.ceil(totalChars / 4))
+            const toolCalls = toolAcc.size ? accumulatorToOpenAIToolCalls(toolAcc) : null
+            onDone(Math.ceil(totalChars / 4), { finishReason, toolCalls: toolCalls?.length ? toolCalls : null })
             return
           }
           try {
-            const parsed = JSON.parse(data)
-            const delta = parsed.choices?.[0]?.delta?.content
-            if (typeof delta === 'string' && delta) {
-              totalChars += delta.length
-              onDelta(delta)
+            const parsed = JSON.parse(data) as {
+              choices?: Array<{
+                delta?: Record<string, unknown>
+                finish_reason?: string | null
+              }>
+            }
+            const choice = parsed.choices?.[0]
+            if (choice?.finish_reason) finishReason = choice.finish_reason
+
+            const d = choice?.delta
+            if (d && typeof d === 'object') {
+              const reasoning = extractReasoningChunk(d)
+              if (reasoning) onReasoningDelta?.(reasoning)
+
+              const delta = d.content
+              if (typeof delta === 'string' && delta) {
+                totalChars += delta.length
+                onDelta(delta)
+              }
+
+              const rawTc = d.tool_calls as
+                | Array<{ index?: number; id?: string; function?: { name?: string; arguments?: string } }>
+                | undefined
+              if (Array.isArray(rawTc) && rawTc.length) mergeToolCallDeltas(toolAcc, rawTc)
             }
           } catch {
             // malformed chunk
@@ -153,7 +196,7 @@ export function streamFree(opts: StreamFreeOptions): () => void {
 
 export type CompleteFreeOptions = {
   provider: FreeProviderInfo
-  messages: Pick<Message, 'role' | 'content' | 'imageUrl'>[]
+  messages: Message[]
   systemPrompt?: string
   signal?: AbortSignal
   temperature?: number
@@ -164,8 +207,8 @@ export async function completeFree(opts: CompleteFreeOptions): Promise<string> {
   const { provider, messages, systemPrompt, signal, temperature, maxTokens } = opts
 
   const apiMessages: ApiMessage[] = systemPrompt
-    ? [{ role: 'system', content: systemPrompt }, ...messages.map(buildApiMessage)]
-    : messages.map(buildApiMessage)
+    ? [{ role: 'system', content: systemPrompt }, ...messages.map((m) => messageToApiMessage(m))]
+    : messages.map((m) => messageToApiMessage(m))
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',

--- a/src/api/openrouter.ts
+++ b/src/api/openrouter.ts
@@ -1,4 +1,5 @@
 import type { Model, Message } from '../types'
+import { mergeToolCallDeltas, accumulatorToOpenAIToolCalls, type ToolCallAccumulator } from './builtinTools'
 
 const BASE_URL = 'https://openrouter.ai/api/v1'
 
@@ -12,8 +13,6 @@ function headers(apiKey: string): Record<string, string> {
 }
 
 export async function fetchModels(apiKey: string): Promise<Model[]> {
-  // OpenRouter's /models endpoint is public; auth is sent if available so that
-  // any private/preview models the user has access to also show up.
   const reqHeaders: Record<string, string> = {
     'HTTP-Referer': window.location.origin,
     'X-Title': 'OpenStarChat',
@@ -25,7 +24,7 @@ export async function fetchModels(apiKey: string): Promise<Model[]> {
     const text = await res.text().catch(() => '')
     throw new Error(`Failed to fetch models: ${res.status} ${text}`)
   }
-  const payload = await res.json().catch(() => null) as { data?: unknown } | null
+  const payload = (await res.json().catch(() => null)) as { data?: unknown } | null
   if (!payload || !Array.isArray(payload.data)) {
     throw new Error('Unexpected response from /models — no `data` array.')
   }
@@ -36,49 +35,117 @@ export type ApiMessagePart =
   | { type: 'text'; text: string }
   | { type: 'image_url'; image_url: { url: string } }
 
-export type ApiMessage = {
-  role: 'user' | 'assistant' | 'system'
-  content: string | ApiMessagePart[]
+export type ApiToolCall = {
+  id: string
+  type: 'function'
+  function: { name: string; arguments: string }
 }
 
-function buildApiMessage(msg: Pick<Message, 'role' | 'content' | 'imageUrl'>): ApiMessage {
-  if (msg.role === 'user' && msg.imageUrl) {
+export type ApiMessage = {
+  role: 'user' | 'assistant' | 'system' | 'tool'
+  content: string | ApiMessagePart[] | null
+  tool_calls?: ApiToolCall[]
+  tool_call_id?: string
+}
+
+function userImageUrls(msg: Pick<Message, 'imageUrl' | 'imageUrls'>): string[] {
+  if (msg.imageUrls?.length) return msg.imageUrls
+  if (msg.imageUrl) return [msg.imageUrl]
+  return []
+}
+
+/** Convert a persisted chat message into an OpenRouter / OpenAI chat message. */
+export function messageToApiMessage(msg: Message): ApiMessage {
+  if (msg.role === 'tool') {
     return {
-      role: 'user',
-      content: [
-        { type: 'image_url', image_url: { url: msg.imageUrl } },
-        { type: 'text', text: msg.content },
-      ],
+      role: 'tool',
+      tool_call_id: msg.toolCallId ?? '',
+      content: msg.content,
     }
   }
-  return { role: msg.role, content: msg.content }
+
+  if (msg.role === 'assistant' && msg.assistantToolCalls) {
+    let calls: ApiToolCall[] = []
+    try {
+      calls = JSON.parse(msg.assistantToolCalls) as ApiToolCall[]
+    } catch {
+      calls = []
+    }
+    return {
+      role: 'assistant',
+      content: msg.content.length ? msg.content : null,
+      tool_calls: calls.length ? calls : undefined,
+    }
+  }
+
+  if (msg.role === 'user') {
+    const imgs = userImageUrls(msg)
+    if (imgs.length > 0) {
+      return {
+        role: 'user',
+        content: [
+          ...imgs.map((url) => ({ type: 'image_url' as const, image_url: { url } })),
+          { type: 'text' as const, text: msg.content },
+        ],
+      }
+    }
+  }
+
+  return { role: msg.role === 'system' ? 'system' : msg.role === 'assistant' ? 'assistant' : 'user', content: msg.content }
+}
+
+export function messagesToApiMessages(messages: Message[]): ApiMessage[] {
+  return messages.map(messageToApiMessage)
 }
 
 export interface CompleteChatOptions {
   apiKey: string
   modelId: string
-  messages: Pick<Message, 'role' | 'content' | 'imageUrl'>[]
+  messages: Message[]
   systemPrompt?: string
   signal?: AbortSignal
   temperature?: number
+  maxTokens?: number
+  tools?: unknown[]
+  toolChoice?: unknown
+  responseFormat?: unknown
 }
 
 export async function completeChat(opts: CompleteChatOptions): Promise<string> {
-  const { apiKey, modelId, messages, systemPrompt, signal, temperature } = opts
+  const {
+    apiKey,
+    modelId,
+    messages,
+    systemPrompt,
+    signal,
+    temperature,
+    maxTokens,
+    tools,
+    toolChoice,
+    responseFormat,
+  } = opts
   const apiMessages: ApiMessage[] = systemPrompt
-    ? [{ role: 'system', content: systemPrompt }, ...messages.map(buildApiMessage)]
-    : messages.map(buildApiMessage)
+    ? [{ role: 'system', content: systemPrompt }, ...messagesToApiMessages(messages)]
+    : messagesToApiMessages(messages)
+
+  const body: Record<string, unknown> = {
+    model: modelId,
+    stream: false,
+    messages: apiMessages,
+    ...(temperature !== undefined ? { temperature } : {}),
+    ...(maxTokens !== undefined ? { max_tokens: maxTokens } : {}),
+  }
+  if (tools?.length) {
+    body.tools = tools
+    body.tool_choice = toolChoice ?? 'auto'
+  }
+  if (responseFormat) body.response_format = responseFormat
 
   const res = await fetch(`${BASE_URL}/chat/completions`, {
     method: 'POST',
     headers: headers(apiKey),
     signal,
-    body: JSON.stringify({
-      model: modelId,
-      stream: false,
-      ...(temperature !== undefined ? { temperature } : {}),
-      messages: apiMessages,
-    }),
+    body: JSON.stringify(body),
   })
   if (!res.ok) {
     const text = await res.text().catch(() => '')
@@ -92,23 +159,70 @@ export async function completeChat(opts: CompleteChatOptions): Promise<string> {
   return content
 }
 
+export interface StreamDoneMeta {
+  finishReason?: string | null
+  toolCalls?: ReturnType<typeof accumulatorToOpenAIToolCalls> | null
+}
+
 export type StreamChatOptions = {
   apiKey: string
   modelId: string
-  messages: Pick<Message, 'role' | 'content' | 'imageUrl'>[]
+  messages: Message[]
   systemPrompt?: string
+  temperature?: number
+  maxTokens?: number
+  tools?: unknown[]
+  toolChoice?: unknown
+  responseFormat?: unknown
   onDelta: (delta: string) => void
-  onDone: (tokenCount?: number) => void
+  onReasoningDelta?: (delta: string) => void
+  onDone: (tokenCount?: number, meta?: StreamDoneMeta) => void
   onError: (err: Error) => void
 }
 
+function extractReasoningChunk(delta: Record<string, unknown>): string {
+  const r = delta.reasoning ?? delta.reasoning_content
+  if (typeof r === 'string') return r
+  if (r && typeof r === 'object' && 'text' in r && typeof (r as { text?: unknown }).text === 'string') {
+    return (r as { text: string }).text
+  }
+  return ''
+}
+
 export function streamChat(opts: StreamChatOptions): () => void {
-  const { apiKey, modelId, messages, systemPrompt, onDelta, onDone, onError } = opts
+  const {
+    apiKey,
+    modelId,
+    messages,
+    systemPrompt,
+    onDelta,
+    onReasoningDelta,
+    onDone,
+    onError,
+    temperature,
+    maxTokens,
+    tools,
+    toolChoice,
+    responseFormat,
+  } = opts
   const controller = new AbortController()
 
   const apiMessages: ApiMessage[] = systemPrompt
-    ? [{ role: 'system', content: systemPrompt }, ...messages.map(buildApiMessage)]
-    : messages.map(buildApiMessage)
+    ? [{ role: 'system', content: systemPrompt }, ...messagesToApiMessages(messages)]
+    : messagesToApiMessages(messages)
+
+  const body: Record<string, unknown> = {
+    model: modelId,
+    stream: true,
+    messages: apiMessages,
+    ...(temperature !== undefined ? { temperature } : {}),
+    ...(maxTokens !== undefined ? { max_tokens: maxTokens } : {}),
+  }
+  if (tools?.length) {
+    body.tools = tools
+    body.tool_choice = toolChoice ?? 'auto'
+  }
+  if (responseFormat) body.response_format = responseFormat
 
   ;(async () => {
     let res: Response
@@ -116,7 +230,7 @@ export function streamChat(opts: StreamChatOptions): () => void {
       res = await fetch(`${BASE_URL}/chat/completions`, {
         method: 'POST',
         headers: headers(apiKey),
-        body: JSON.stringify({ model: modelId, stream: true, messages: apiMessages }),
+        body: JSON.stringify(body),
         signal: controller.signal,
       })
     } catch (err) {
@@ -134,12 +248,15 @@ export function streamChat(opts: StreamChatOptions): () => void {
     const decoder = new TextDecoder()
     let buffer = ''
     let totalChars = 0
+    let finishReason: string | null | undefined
+    const toolAcc: ToolCallAccumulator = new Map()
 
     try {
       while (true) {
         const { done, value } = await reader.read()
         if (done) {
-          onDone(Math.ceil(totalChars / 4))
+          const toolCalls = toolAcc.size ? accumulatorToOpenAIToolCalls(toolAcc) : null
+          onDone(Math.ceil(totalChars / 4), { finishReason, toolCalls: toolCalls?.length ? toolCalls : null })
           break
         }
 
@@ -152,15 +269,35 @@ export function streamChat(opts: StreamChatOptions): () => void {
           if (!trimmed.startsWith('data: ')) continue
           const data = trimmed.slice(6)
           if (data === '[DONE]') {
-            onDone(Math.ceil(totalChars / 4))
+            const toolCalls = toolAcc.size ? accumulatorToOpenAIToolCalls(toolAcc) : null
+            onDone(Math.ceil(totalChars / 4), { finishReason, toolCalls: toolCalls?.length ? toolCalls : null })
             return
           }
           try {
-            const parsed = JSON.parse(data)
-            const delta = parsed.choices?.[0]?.delta?.content
-            if (typeof delta === 'string' && delta) {
-              totalChars += delta.length
-              onDelta(delta)
+            const parsed = JSON.parse(data) as {
+              choices?: Array<{
+                delta?: Record<string, unknown>
+                finish_reason?: string | null
+              }>
+            }
+            const choice = parsed.choices?.[0]
+            if (choice?.finish_reason) finishReason = choice.finish_reason
+
+            const d = choice?.delta
+            if (d && typeof d === 'object') {
+              const reasoning = extractReasoningChunk(d)
+              if (reasoning) onReasoningDelta?.(reasoning)
+
+              const delta = d.content
+              if (typeof delta === 'string' && delta) {
+                totalChars += delta.length
+                onDelta(delta)
+              }
+
+              const rawTc = d.tool_calls as
+                | Array<{ index?: number; id?: string; function?: { name?: string; arguments?: string } }>
+                | undefined
+              if (Array.isArray(rawTc) && rawTc.length) mergeToolCallDeltas(toolAcc, rawTc)
             }
           } catch {
             // malformed chunk — skip

--- a/src/components/bookmarks/BookmarksPanel.tsx
+++ b/src/components/bookmarks/BookmarksPanel.tsx
@@ -57,7 +57,7 @@ export function BookmarksPanel({ onClose, onNavigateToChat }: BookmarksPanelProp
                     </button>
                     <div className="flex items-center gap-2 shrink-0">
                       <span className="text-xs text-muted">
-                        {message.role === 'user' ? 'You' : 'AI'}
+                        {message.role === 'user' ? 'You' : message.role === 'tool' ? 'Tool' : 'AI'}
                       </span>
                       <button
                         onClick={() => toggleBookmarkMessage(chat.id, message.id)}

--- a/src/components/characters/AICharacterBuilder.tsx
+++ b/src/components/characters/AICharacterBuilder.tsx
@@ -143,7 +143,7 @@ export function AICharacterBuilder({ onClose, onAccept, mode }: AICharacterBuild
         modelId,
         systemPrompt,
         temperature: 0.9,
-        messages: [{ role: 'user', content: userContent }],
+        messages: [{ id: 'builder', role: 'user', content: userContent, createdAt: Date.now() }],
       })
       setRawOutput(text)
       const result = tryParseCharacter(text)

--- a/src/components/characters/CharacterTranscriber.tsx
+++ b/src/components/characters/CharacterTranscriber.tsx
@@ -6,7 +6,7 @@ import {
 import { useSettingsStore } from '../../store/settingsStore'
 import { completeChat } from '../../api/openrouter'
 import { ModelPicker } from '../models/ModelPicker'
-import type { Character } from '../../types'
+import type { Character, Message } from '../../types'
 
 const EMOJI_OPTIONS = ['🌸', '💻', '✍️', '🧙', '🃏', '🔮', '🦊', '🐉', '🌙', '⚡', '🎯', '🧪', '🤖', '👾', '🦋']
 const COLOR_OPTIONS = ['#bd93f9', '#50fa7b', '#ffb86c', '#8be9fd', '#ff79c6', '#ff5555', '#f1fa8c', '#268bd2', '#2aa198', '#859900']
@@ -216,19 +216,17 @@ export function CharacterTranscriber({ onAccept, onCancel }: CharacterTranscribe
         ? `Source material follows. Synthesize a single character sheet that faithfully reflects every concrete detail.\n\n${segments.join('\n\n')}`
         : 'The only source material is the attached reference image(s). Build the character sheet primarily from what you can see.'
 
-      const userContent: Array<
-        | { role: 'user'; content: string }
-      > = [
-        { role: 'user', content: userText },
+      const userContent: Message[] = [
+        { id: 'u0', role: 'user', content: userText, createdAt: Date.now() },
       ]
 
-      // Send reference images as multimodal user messages so vision-capable models can read them.
-      // We piggyback on the existing API by attaching one image per message.
-      // (completeChat supports a single imageUrl per message via the buildApiMessage helper.)
-      const imageMessages = refImages.map((img) => ({
+      const imageMessages: Message[] = refImages.map((img, i) => ({
+        id: `img-${i}`,
         role: 'user' as const,
         content: 'Reference image for the character.',
         imageUrl: img.content,
+        imageUrls: [img.content],
+        createdAt: Date.now() + i + 1,
       }))
 
       const text = await completeChat({

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -1,14 +1,20 @@
 import { useRef, useEffect, useState, useCallback } from 'react'
-import { Send, Square, ChevronDown, Paperclip, X, Mic, MicOff, Thermometer, SlidersHorizontal } from 'lucide-react'
+import { Send, Square, ChevronDown, Paperclip, X, Mic, MicOff, Thermometer, SlidersHorizontal, Wrench, Braces } from 'lucide-react'
 import clsx from 'clsx'
-import type { Chat, Character } from '../../types'
+import type { Chat, Character, Message } from '../../types'
 import { useSettingsStore } from '../../store/settingsStore'
 import { useChatStore } from '../../store/chatStore'
 import { completeFree, getPollinationsProvider, getCustomProvider } from '../../api/freeProvider'
 import { completeChat } from '../../api/openrouter'
+import { MarkdownContent } from './MarkdownContent'
+import { extractPdfTextAsString } from '../../utils/extractPdfText'
 
-interface SpeechResult { readonly [index: number]: { transcript: string } }
-interface SpeechEvent { results: ArrayLike<SpeechResult> }
+interface SpeechResult {
+  readonly [index: number]: { transcript: string }
+}
+interface SpeechEvent {
+  results: ArrayLike<SpeechResult>
+}
 type SpeechRecognitionInstance = {
   continuous: boolean
   interimResults: boolean
@@ -27,9 +33,10 @@ function createSpeechRecognition(): SpeechRecognitionInstance | null {
   return new (Ctor as new () => SpeechRecognitionInstance)()
 }
 
-const HAS_SPEECH = typeof window !== 'undefined' &&
-  !!(window as unknown as Record<string, unknown>).SpeechRecognition ||
-  !!(window as unknown as Record<string, unknown>).webkitSpeechRecognition
+const HAS_SPEECH =
+  typeof window !== 'undefined' &&
+  (!!(window as unknown as Record<string, unknown>).SpeechRecognition ||
+    !!(window as unknown as Record<string, unknown>).webkitSpeechRecognition)
 
 const DRAFT_KEY = 'openstarchat-drafts'
 
@@ -37,7 +44,9 @@ function loadDraft(chatId: string): string {
   try {
     const drafts = JSON.parse(localStorage.getItem(DRAFT_KEY) || '{}')
     return drafts[chatId] ?? ''
-  } catch { return '' }
+  } catch {
+    return ''
+  }
 }
 
 function saveDraft(chatId: string, text: string) {
@@ -46,14 +55,26 @@ function saveDraft(chatId: string, text: string) {
     if (text) drafts[chatId] = text
     else delete drafts[chatId]
     localStorage.setItem(DRAFT_KEY, JSON.stringify(drafts))
-  } catch { /* noop */ }
+  } catch {
+    /* noop */
+  }
 }
+
+type Attachment =
+  | { id: string; kind: 'image'; dataUrl: string; name: string }
+  | { id: string; kind: 'file_text'; name: string; text: string }
+
+const MAX_ATTACHMENTS = 8
+const MAX_IMAGES = 4
 
 interface ChatInputProps {
   chat: Chat
   character: Character | null
   isStreaming: boolean
-  onSend: (content: string, imageUrl?: string) => void
+  onSend: (
+    content: string,
+    opts?: { imageUrls?: string[]; imageUrl?: string; fileExtracts?: { name: string; text: string }[] },
+  ) => void
   onCancel: () => void
   onOpenModelPicker: () => void
   onOpenCharacters: () => void
@@ -69,9 +90,10 @@ export function ChatInput({
   onOpenCharacters,
 }: ChatInputProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const underlayRef = useRef<HTMLDivElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
-  const [attachedImage, setAttachedImage] = useState<string | null>(null)
-  const [attachedName, setAttachedName] = useState<string>('')
+  const [draft, setDraft] = useState('')
+  const [attachments, setAttachments] = useState<Attachment[]>([])
   const [ghostText, setGhostText] = useState('')
   const [isListening, setIsListening] = useState(false)
   const [showParams, setShowParams] = useState(false)
@@ -86,109 +108,108 @@ export function ChatInput({
 
   function autosize() {
     const ta = textareaRef.current
+    const under = underlayRef.current
     if (!ta) return
     ta.style.height = 'auto'
-    ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`
+    const h = Math.min(ta.scrollHeight, 200)
+    ta.style.height = `${h}px`
+    if (under) under.style.height = `${h}px`
   }
 
-  // Restore draft when chat changes
   useEffect(() => {
-    const ta = textareaRef.current
-    if (!ta) return
-    // Save draft for previous chat
     if (lastChatIdRef.current !== chat.id) {
-      saveDraft(lastChatIdRef.current, ta.value)
+      saveDraft(lastChatIdRef.current, draft)
     }
     lastChatIdRef.current = chat.id
-    // Load draft for current chat
-    ta.value = loadDraft(chat.id)
-    autosize()
+    const next = loadDraft(chat.id)
+    setDraft(next)
+    setAttachments([])
     setGhostText('')
+    setTimeout(() => autosize(), 0)
   }, [chat.id])
 
-  // Periodically save draft as user types
-  const handleInput = useCallback(() => {
+  useEffect(() => {
     autosize()
-    const val = textareaRef.current?.value ?? ''
-    saveDraft(chat.id, val)
+  }, [draft])
 
-    // Predictive text
-    setGhostText('')
-    if (predictionTimerRef.current) clearTimeout(predictionTimerRef.current)
-    if (predictionAbortRef.current) predictionAbortRef.current.abort()
-
-    if (predictiveText && val.length >= 5) {
-      predictionTimerRef.current = setTimeout(() => {
-        requestPrediction(val)
-      }, 800)
-    }
-  }, [chat.id, predictiveText])
-
-  // Save draft on unmount
   useEffect(() => {
     return () => {
-      const ta = textareaRef.current
-      if (ta) saveDraft(chat.id, ta.value)
+      saveDraft(chat.id, draft)
     }
-  }, [chat.id])
+  }, [chat.id, draft])
 
-  const requestPrediction = useCallback(async (text: string) => {
-    const controller = new AbortController()
-    predictionAbortRef.current = controller
+  const requestPrediction = useCallback(
+    async (text: string) => {
+      const controller = new AbortController()
+      predictionAbortRef.current = controller
+      const msgs: Message[] = [{ id: 'pred', role: 'user', content: text, createdAt: Date.now() }]
+      const sysPrompt =
+        'You are an autocomplete engine. The user is typing a message in a chat app. Continue their text naturally with 5-15 words. Output ONLY the completion text, nothing else. Do not repeat what they already typed.'
 
-    const msgs = [{ role: 'user' as const, content: text }]
-    const sysPrompt = 'You are an autocomplete engine. The user is typing a message in a chat app. Continue their text naturally with 5-15 words. Output ONLY the completion text, nothing else. Do not repeat what they already typed.'
-
-    try {
-      let completion: string
-
-      if (freeProvider.enabled && !apiKey) {
-        const provider = freeProvider.type === 'pollinations'
-          ? getPollinationsProvider(freeProvider.pollinationsKey, freeProvider.pollinationsModel)
-          : getCustomProvider(freeProvider.customUrl, freeProvider.customKey, freeProvider.customModel)
-        completion = await completeFree({
-          provider,
-          messages: msgs,
-          systemPrompt: sysPrompt,
-          signal: controller.signal,
-          temperature: 0.3,
-          maxTokens: 30,
-        })
-      } else if (apiKey) {
-        completion = await completeChat({
-          apiKey,
-          modelId: 'openai/gpt-4o-mini',
-          messages: msgs,
-          systemPrompt: sysPrompt,
-          signal: controller.signal,
-          temperature: 0.3,
-        })
-      } else {
-        return
+      try {
+        let completion: string
+        if (freeProvider.enabled && !apiKey) {
+          const provider =
+            freeProvider.type === 'pollinations'
+              ? getPollinationsProvider(freeProvider.pollinationsKey, freeProvider.pollinationsModel)
+              : getCustomProvider(freeProvider.customUrl, freeProvider.customKey, freeProvider.customModel)
+          completion = await completeFree({
+            provider,
+            messages: msgs,
+            systemPrompt: sysPrompt,
+            signal: controller.signal,
+            temperature: 0.3,
+            maxTokens: 30,
+          })
+        } else if (apiKey) {
+          completion = await completeChat({
+            apiKey,
+            modelId: 'openai/gpt-4o-mini',
+            messages: msgs,
+            systemPrompt: sysPrompt,
+            signal: controller.signal,
+            temperature: 0.3,
+            maxTokens: 30,
+          })
+        } else {
+          return
+        }
+        if (!controller.signal.aborted && completion) {
+          setGhostText(completion.trim())
+        }
+      } catch {
+        /* prediction failed silently */
       }
+    },
+    [apiKey, freeProvider],
+  )
 
-      if (!controller.signal.aborted && completion) {
-        setGhostText(completion.trim())
+  const handleInput = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const val = e.target.value
+      setDraft(val)
+      saveDraft(chat.id, val)
+      setGhostText('')
+      if (predictionTimerRef.current) clearTimeout(predictionTimerRef.current)
+      if (predictionAbortRef.current) predictionAbortRef.current.abort()
+      if (predictiveText && val.length >= 5) {
+        predictionTimerRef.current = setTimeout(() => {
+          void requestPrediction(val)
+        }, 800)
       }
-    } catch {
-      // prediction failed silently
-    }
-  }, [apiKey, freeProvider])
+    },
+    [chat.id, predictiveText, requestPrediction],
+  )
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    // Accept prediction with Tab
     if (e.key === 'Tab' && ghostText && !e.shiftKey) {
       e.preventDefault()
-      const ta = textareaRef.current
-      if (ta) {
-        ta.value = ta.value + ghostText
-        saveDraft(chat.id, ta.value)
-        autosize()
-      }
+      const next = draft + ghostText
+      setDraft(next)
+      saveDraft(chat.id, next)
       setGhostText('')
       return
     }
-
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
       submit()
@@ -196,18 +217,27 @@ export function ChatInput({
   }
 
   function submit() {
-    const val = textareaRef.current?.value.trim()
-    if ((!val && !attachedImage) || isStreaming) return
-    if (textareaRef.current) {
-      textareaRef.current.value = ''
-      autosize()
-    }
+    const val = draft.trim()
+    const images = attachments.filter((a): a is Attachment & { kind: 'image' } => a.kind === 'image')
+    const files = attachments.filter((a): a is Attachment & { kind: 'file_text' } => a.kind === 'file_text')
+    if ((!val && images.length === 0) || isStreaming) return
+    const imageUrls = images.slice(0, MAX_IMAGES).map((i) => i.dataUrl)
+    const fileExtracts = files.map((f) => ({ name: f.name, text: f.text }))
+    setDraft('')
     saveDraft(chat.id, '')
     setGhostText('')
-    const img = attachedImage ?? undefined
-    setAttachedImage(null)
-    setAttachedName('')
-    onSend(val ?? '', img)
+    setAttachments([])
+    if (imageUrls.length === 1) {
+      onSend(val, {
+        imageUrl: imageUrls[0],
+        imageUrls,
+        fileExtracts: fileExtracts.length ? fileExtracts : undefined,
+      })
+    } else if (imageUrls.length > 1) {
+      onSend(val, { imageUrls, fileExtracts: fileExtracts.length ? fileExtracts : undefined })
+    } else {
+      onSend(val, { fileExtracts: fileExtracts.length ? fileExtracts : undefined })
+    }
   }
 
   function toggleVoice() {
@@ -225,12 +255,8 @@ export function ChatInput({
       const transcript = Array.from(event.results)
         .map((r) => r[0].transcript)
         .join('')
-      const ta = textareaRef.current
-      if (ta) {
-        ta.value = transcript
-        saveDraft(chat.id, transcript)
-        autosize()
-      }
+      setDraft(transcript)
+      saveDraft(chat.id, transcript)
     }
     recognition.onend = () => setIsListening(false)
     recognition.onerror = () => setIsListening(false)
@@ -239,29 +265,66 @@ export function ChatInput({
     setIsListening(true)
   }
 
-  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0]
-    if (!file) return
-    if (!file.type.startsWith('image/')) return
-    const reader = new FileReader()
-    reader.onload = () => {
-      setAttachedImage(reader.result as string)
-      setAttachedName(file.name)
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const fileList = e.target.files
+    if (!fileList?.length) return
+    const next: Attachment[] = [...attachments]
+    for (const file of Array.from(fileList)) {
+      if (next.length >= MAX_ATTACHMENTS) break
+      if (file.type.startsWith('image/')) {
+        const dataUrl = await new Promise<string>((resolve, reject) => {
+          const reader = new FileReader()
+          reader.onload = () => resolve(reader.result as string)
+          reader.onerror = () => reject(new Error('read'))
+          reader.readAsDataURL(file)
+        })
+        const imgs = next.filter((a) => a.kind === 'image')
+        if (imgs.length >= MAX_IMAGES) continue
+        next.push({ id: `${Date.now()}-${file.name}`, kind: 'image', dataUrl, name: file.name })
+      } else if (file.type === 'application/pdf') {
+        try {
+          const text = await extractPdfTextAsString(file)
+          next.push({
+            id: `${Date.now()}-${file.name}`,
+            kind: 'file_text',
+            name: file.name,
+            text: text || '(no extractable text in PDF)',
+          })
+        } catch {
+          next.push({
+            id: `${Date.now()}-${file.name}`,
+            kind: 'file_text',
+            name: file.name,
+            text: '(could not read PDF — try copying text manually)',
+          })
+        }
+      } else if (
+        file.type.startsWith('text/') ||
+        file.name.endsWith('.md') ||
+        file.name.endsWith('.txt') ||
+        file.name.endsWith('.json') ||
+        file.name.endsWith('.csv')
+      ) {
+        const text = await file.text()
+        next.push({ id: `${Date.now()}-${file.name}`, kind: 'file_text', name: file.name, text })
+      }
     }
-    reader.readAsDataURL(file)
+    setAttachments(next)
     e.target.value = ''
+  }
+
+  function removeAttachment(id: string) {
+    setAttachments((prev) => prev.filter((a) => a.id !== id))
   }
 
   const modelParts = chat.modelId.split('/')
   const provider = modelParts[0] ?? ''
   const modelShort = modelParts.slice(1).join('/') || chat.modelId
 
+  const imageAttachments = attachments.filter((a) => a.kind === 'image')
+
   return (
-    <div
-      className="border-t border-subtle p-3"
-      style={{ background: 'var(--bg-secondary)' }}
-    >
-      {/* Context bar */}
+    <div className="border-t border-subtle p-3" style={{ background: 'var(--bg-secondary)' }}>
       <div className="flex items-center gap-2 mb-2 flex-wrap">
         <button
           onClick={onOpenModelPicker}
@@ -278,7 +341,7 @@ export function ChatInput({
           onClick={onOpenCharacters}
           className={clsx(
             'flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full border border-subtle btn-ghost font-medium',
-            character ? 'border-accent' : ''
+            character ? 'border-accent' : '',
           )}
           style={character ? { borderColor: character.color } : undefined}
           title="Change character"
@@ -286,11 +349,7 @@ export function ChatInput({
           {character ? (
             <>
               {character.avatarUrl ? (
-                <img
-                  src={character.avatarUrl}
-                  alt=""
-                  className="w-4 h-4 rounded-full object-cover"
-                />
+                <img src={character.avatarUrl} alt="" className="w-4 h-4 rounded-full object-cover" />
               ) : (
                 <span>{character.emoji}</span>
               )}
@@ -312,81 +371,124 @@ export function ChatInput({
           </span>
         )}
 
-        {/* Params toggle */}
         <button
           onClick={() => setShowParams((v) => !v)}
           className={clsx(
             'flex items-center gap-1 text-xs px-2 py-1 rounded-full border border-subtle btn-ghost',
-            showParams && 'accent-text'
+            showParams && 'accent-text',
           )}
           style={showParams ? { borderColor: 'var(--accent)' } : undefined}
-          title="Temperature & max tokens"
+          title="Model parameters & advanced"
         >
           <SlidersHorizontal size={11} />
         </button>
       </div>
 
-      {/* Temperature / Max Tokens panel */}
       {showParams && (
-        <div
-          className="flex items-center gap-4 mb-2 px-2 py-2 rounded-lg text-xs"
-          style={{ background: 'var(--bg-tertiary)' }}
-        >
-          <div className="flex items-center gap-2 flex-1">
-            <Thermometer size={12} className="text-muted shrink-0" />
-            <span className="text-muted shrink-0">Temp</span>
-            <input
-              type="range"
-              min={0}
-              max={2}
-              step={0.1}
-              value={chat.temperature ?? 1}
-              onChange={(e) => updateChat(chat.id, { temperature: parseFloat(e.target.value) })}
-              className="flex-1 accent-accent"
-            />
-            <span className="w-6 text-right font-mono">{(chat.temperature ?? 1).toFixed(1)}</span>
+        <div className="flex flex-col gap-3 mb-2 px-2 py-2 rounded-lg text-xs" style={{ background: 'var(--bg-tertiary)' }}>
+          <div className="flex items-center gap-4 flex-wrap">
+            <div className="flex items-center gap-2 flex-1 min-w-[200px]">
+              <Thermometer size={12} className="text-muted shrink-0" />
+              <span className="text-muted shrink-0">Temp</span>
+              <input
+                type="range"
+                min={0}
+                max={2}
+                step={0.1}
+                value={chat.temperature ?? 1}
+                onChange={(e) => updateChat(chat.id, { temperature: parseFloat(e.target.value) })}
+                className="flex-1 accent-accent"
+              />
+              <span className="w-6 text-right font-mono">{(chat.temperature ?? 1).toFixed(1)}</span>
+            </div>
+            <div className="flex items-center gap-2 flex-1 min-w-[200px]">
+              <span className="text-muted shrink-0">Max</span>
+              <input
+                type="number"
+                min={1}
+                max={128000}
+                step={256}
+                value={chat.maxTokens ?? 4096}
+                onChange={(e) => updateChat(chat.id, { maxTokens: parseInt(e.target.value, 10) || 4096 })}
+                className="w-20 px-2 py-1 rounded border border-subtle bg-transparent outline-none text-xs font-mono"
+                style={{ color: 'var(--text-primary)', background: 'var(--bg-secondary)' }}
+              />
+              <span className="text-muted">tokens</span>
+            </div>
           </div>
-          <div className="flex items-center gap-2 flex-1">
-            <span className="text-muted shrink-0">Max</span>
+
+          <label className="flex items-start gap-2 cursor-pointer">
             <input
-              type="number"
-              min={1}
-              max={128000}
-              step={256}
-              value={chat.maxTokens ?? 4096}
-              onChange={(e) => updateChat(chat.id, { maxTokens: parseInt(e.target.value) || 4096 })}
-              className="w-20 px-2 py-1 rounded border border-subtle bg-transparent outline-none text-xs font-mono"
+              type="checkbox"
+              checked={!!chat.experimentalTools}
+              onChange={(e) => updateChat(chat.id, { experimentalTools: e.target.checked })}
+              className="mt-0.5"
+            />
+            <span>
+              <span className="flex items-center gap-1 font-medium">
+                <Wrench size={12} /> Built-in tools (time, random int)
+              </span>
+              <span className="block text-muted mt-0.5">
+                The model may call safe tools that run in your browser. Optional JSON below merges with these; only
+                built-in tool names execute locally.
+              </span>
+            </span>
+          </label>
+
+          <div>
+            <span className="flex items-center gap-1 text-muted mb-1">
+              <Braces size={11} /> Extra tools JSON (optional array)
+            </span>
+            <textarea
+              value={chat.toolsJson ?? ''}
+              onChange={(e) => updateChat(chat.id, { toolsJson: e.target.value })}
+              placeholder='[{"type":"function","function":{"name":"…","description":"…","parameters":{…}}}]'
+              rows={3}
+              className="w-full px-2 py-1.5 rounded border border-subtle bg-transparent outline-none font-mono text-[11px]"
               style={{ color: 'var(--text-primary)', background: 'var(--bg-secondary)' }}
             />
-            <span className="text-muted">tokens</span>
+          </div>
+
+          <div>
+            <span className="text-muted mb-1 block">JSON Schema for structured replies (optional)</span>
+            <textarea
+              value={chat.jsonSchemaText ?? ''}
+              onChange={(e) => updateChat(chat.id, { jsonSchemaText: e.target.value })}
+              placeholder='{ "type": "object", "properties": { … } }'
+              rows={4}
+              className="w-full px-2 py-1.5 rounded border border-subtle bg-transparent outline-none font-mono text-[11px]"
+              style={{ color: 'var(--text-primary)', background: 'var(--bg-secondary)' }}
+            />
           </div>
         </div>
       )}
 
-      {/* Image preview */}
-      {attachedImage && (
-        <div className="flex items-center gap-2 mb-2 px-1">
-          <img src={attachedImage} alt="Attachment preview" className="h-12 w-12 object-cover rounded-lg border border-subtle" />
-          <span className="text-xs text-muted truncate flex-1">{attachedName}</span>
-          <button
-            onClick={() => { setAttachedImage(null); setAttachedName('') }}
-            className="btn-ghost p-1 rounded"
-            title="Remove image"
-          >
-            <X size={13} />
-          </button>
+      {attachments.length > 0 && (
+        <div className="flex flex-wrap gap-2 mb-2">
+          {attachments.map((a) => (
+            <div
+              key={a.id}
+              className="flex items-center gap-1.5 px-2 py-1 rounded-lg border border-subtle text-xs max-w-[220px]"
+              style={{ background: 'var(--bg-tertiary)' }}
+            >
+              {a.kind === 'image' ? (
+                <img src={a.dataUrl} alt="" className="h-8 w-8 object-cover rounded" />
+              ) : (
+                <span className="text-muted truncate">{a.name}</span>
+              )}
+              <button type="button" onClick={() => removeAttachment(a.id)} className="btn-ghost p-0.5 rounded" title="Remove">
+                <X size={12} />
+              </button>
+            </div>
+          ))}
         </div>
       )}
 
-      {/* Input row */}
-      <div
-        className="flex items-end gap-2 rounded-xl border border-subtle p-2"
-        style={{ background: 'var(--bg-tertiary)' }}
-      >
+      <div className="flex items-end gap-2 rounded-xl border border-subtle p-2" style={{ background: 'var(--bg-tertiary)' }}>
         <button
           onClick={() => fileInputRef.current?.click()}
           className="shrink-0 p-1.5 rounded-lg btn-ghost"
-          title="Attach image"
+          title="Attach images, PDF, or text files"
           disabled={isStreaming}
         >
           <Paperclip size={15} />
@@ -394,31 +496,46 @@ export function ChatInput({
         <input
           ref={fileInputRef}
           type="file"
-          accept="image/*"
+          accept="image/*,application/pdf,text/*,.md,.txt,.json,.csv"
+          multiple
           className="hidden"
-          onChange={handleFileChange}
+          onChange={(e) => void handleFileChange(e)}
         />
 
-        <div className="flex-1 relative min-h-[1.5rem]">
+        <div className="flex-1 relative min-h-[1.5rem] max-h-[200px] overflow-hidden">
+          <div
+            ref={underlayRef}
+            className="absolute inset-0 overflow-y-auto pointer-events-none z-0 px-0 py-0 text-sm leading-relaxed opacity-90"
+            aria-hidden
+          >
+            <MarkdownContent text={draft || '\u00a0'} variant="composer" />
+          </div>
           <textarea
             ref={textareaRef}
             rows={1}
+            value={draft}
+            onChange={handleInput}
+            onScroll={(e) => {
+              if (underlayRef.current) underlayRef.current.scrollTop = e.currentTarget.scrollTop
+            }}
             placeholder="Message… (Enter to send, Shift+Enter for newline)"
             onKeyDown={handleKeyDown}
-            onInput={handleInput}
             disabled={isStreaming}
-            className="w-full bg-transparent outline-none resize-none text-sm leading-relaxed min-h-[1.5rem] max-h-[200px] relative z-10"
-            style={{ color: 'var(--text-primary)' }}
+            spellCheck
+            className="composer-md-input w-full bg-transparent outline-none resize-none text-sm leading-relaxed min-h-[1.5rem] max-h-[200px] relative z-10 overflow-y-auto text-transparent caret-auto"
+            style={{ caretColor: 'var(--text-primary)' }}
           />
           {ghostText && (
             <div
-              className="absolute top-0 left-0 text-sm leading-relaxed pointer-events-none whitespace-pre-wrap break-words w-full"
-              style={{ color: 'var(--text-secondary)', opacity: 0.4 }}
+              className="absolute top-0 left-0 z-20 text-sm leading-relaxed pointer-events-none whitespace-pre-wrap break-words w-full"
+              style={{ color: 'var(--text-secondary)', opacity: 0.45 }}
               aria-hidden
             >
-              <span style={{ visibility: 'hidden' }}>{textareaRef.current?.value ?? ''}</span>
+              <span className="invisible">{draft}</span>
               <span>{ghostText}</span>
-              <span className="text-xs ml-1" style={{ opacity: 0.6 }}>⇥ Tab</span>
+              <span className="text-xs ml-1" style={{ opacity: 0.65 }}>
+                ⇥ Tab
+              </span>
             </div>
           )}
         </div>
@@ -446,7 +563,8 @@ export function ChatInput({
         ) : (
           <button
             onClick={submit}
-            className="shrink-0 p-2 rounded-lg btn-primary"
+            disabled={!draft.trim() && imageAttachments.length === 0}
+            className="shrink-0 p-2 rounded-lg btn-primary disabled:opacity-40"
             title="Send (Enter)"
           >
             <Send size={14} />

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -57,7 +57,10 @@ export function ChatView({
     }
   }, [activeChat?.messages.length, activeChat?.messages[activeChat.messages.length - 1]?.content, isAtBottom])
 
-  function handleSend(content: string, imageUrl?: string) {
+  function handleSend(
+    content: string,
+    opts?: { imageUrls?: string[]; imageUrl?: string; fileExtracts?: { name: string; text: string }[] },
+  ) {
     if (!apiKey && !useFreeProvider) {
       onNeedApiKey()
       return
@@ -67,7 +70,7 @@ export function ChatView({
     if (!chatId) {
       chatId = createChat(defaultModelId)
     }
-    sendMessage(chatId, content, imageUrl)
+    sendMessage(chatId, content, opts)
   }
 
   function handleRegenerate() {

--- a/src/components/chat/CompareView.tsx
+++ b/src/components/chat/CompareView.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx'
 import { streamChat } from '../../api/openrouter'
 import { streamFree, getPollinationsProvider, getCustomProvider } from '../../api/freeProvider'
 import { useSettingsStore } from '../../store/settingsStore'
+import type { Message } from '../../types'
 
 interface CompareViewProps {
   onClose: () => void
@@ -70,7 +71,9 @@ export const CompareView = forwardRef<CompareViewHandle, CompareViewProps>(
     setResponses(initial)
 
     activeModels.forEach((modelId, idx) => {
-      const messages = [{ role: 'user' as const, content: input.trim() }]
+      const messages: Message[] = [
+        { id: 'compare', role: 'user', content: input.trim(), createdAt: Date.now() },
+      ]
 
       const onDelta = (delta: string) => {
         setResponses((prev) => {

--- a/src/components/chat/MarkdownContent.tsx
+++ b/src/components/chat/MarkdownContent.tsx
@@ -1,0 +1,116 @@
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import remarkBreaks from 'remark-breaks'
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
+import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
+
+interface MarkdownContentProps {
+  text: string
+  /** Assistant bubbles use full code blocks; composer overlay uses lightweight code styling */
+  variant?: 'assistant' | 'user' | 'composer'
+  isStreaming?: boolean
+}
+
+export function MarkdownContent({
+  text,
+  variant = 'assistant',
+  isStreaming,
+}: MarkdownContentProps) {
+  const lite = variant === 'composer'
+  const proseClass =
+    variant === 'assistant'
+      ? 'prose prose-sm max-w-none'
+      : 'prose prose-sm max-w-none [&_p]:my-0.5 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0'
+
+  return (
+    <div className={proseClass} style={{ color: 'var(--text-primary)' }}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, remarkBreaks]}
+        disallowedElements={['script']}
+        components={{
+          code({ className, children, ...props }) {
+            const match = /language-(\w+)/.exec(className || '')
+            const isBlock = match !== null
+            if (lite || !isBlock) {
+              return (
+                <code
+                  className={className}
+                  style={{
+                    background: 'var(--bg-tertiary)',
+                    padding: '0.15em 0.35em',
+                    borderRadius: '0.25rem',
+                    fontSize: '0.85em',
+                  }}
+                  {...props}
+                >
+                  {children}
+                </code>
+              )
+            }
+            return (
+              <SyntaxHighlighter
+                style={oneDark as never}
+                language={match[1]}
+                PreTag="div"
+                customStyle={{ borderRadius: '0.5rem', fontSize: '0.8rem' }}
+              >
+                {String(children).replace(/\n$/, '')}
+              </SyntaxHighlighter>
+            )
+          },
+          p({ children }) {
+            return <p style={{ margin: '0.4em 0' }}>{children}</p>
+          },
+          a({ href, children }) {
+            return (
+              <a
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ color: 'var(--accent)' }}
+              >
+                {children}
+              </a>
+            )
+          },
+          table({ children }) {
+            return (
+              <div style={{ overflowX: 'auto' }}>
+                <table
+                  style={{ borderCollapse: 'collapse', width: '100%', fontSize: '0.85rem' }}
+                >
+                  {children}
+                </table>
+              </div>
+            )
+          },
+          th({ children }) {
+            return (
+              <th
+                style={{
+                  borderBottom: '1px solid var(--border)',
+                  padding: '0.4rem 0.75rem',
+                  textAlign: 'left',
+                  color: 'var(--text-secondary)',
+                  fontWeight: 600,
+                }}
+              >
+                {children}
+              </th>
+            )
+          },
+          td({ children }) {
+            return (
+              <td style={{ borderBottom: '1px solid var(--border)', padding: '0.4rem 0.75rem' }}>
+                {children}
+              </td>
+            )
+          },
+        }}
+      >
+        {text}
+      </ReactMarkdown>
+      {isStreaming && text ? <span className="streaming-cursor" /> : null}
+    </div>
+  )
+}

--- a/src/components/chat/Message.tsx
+++ b/src/components/chat/Message.tsx
@@ -1,11 +1,25 @@
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import remarkBreaks from 'remark-breaks'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
-import { Copy, Check, Bookmark, BookmarkCheck, Edit2, RefreshCw, GitBranch, X } from 'lucide-react'
+import {
+  Copy,
+  Check,
+  Bookmark,
+  BookmarkCheck,
+  Edit2,
+  RefreshCw,
+  GitBranch,
+  X,
+  Volume2,
+} from 'lucide-react'
 import clsx from 'clsx'
 import type { Message as MessageType, Character } from '../../types'
+import { MarkdownContent } from './MarkdownContent'
+import { useSettingsStore } from '../../store/settingsStore'
+import { elevenLabsSpeak } from '../../api/elevenlabs'
 
 interface MessageProps {
   message: MessageType
@@ -42,6 +56,16 @@ function estimateCost(tokenCount: number): string | null {
   return `~${tokenCount} tokens`
 }
 
+function userImageUrls(m: MessageType): string[] {
+  if (m.imageUrls?.length) return m.imageUrls
+  if (m.imageUrl) return [m.imageUrl]
+  return []
+}
+
+function stripMdForSpeech(s: string): string {
+  return s.replace(/```[\s\S]*?```/g, ' ').replace(/`+/g, '').replace(/\*\*|__/g, '').replace(/[*_]/g, '').trim()
+}
+
 export function Message({
   message,
   chatId: _chatId,
@@ -54,9 +78,43 @@ export function Message({
   onBranch,
 }: MessageProps) {
   const isUser = message.role === 'user'
-  const showCharAvatar = !isUser && !!character
+  const isTool = message.role === 'tool'
+  const showCharAvatar = !isUser && !isTool && !!character
   const [editing, setEditing] = useState(false)
   const [editDraft, setEditDraft] = useState(message.content)
+  const [ttsBusy, setTtsBusy] = useState(false)
+
+  const ttsProvider = useSettingsStore((s) => s.ttsProvider)
+  const elevenLabsApiKey = useSettingsStore((s) => s.elevenLabsApiKey)
+  const elevenLabsVoiceId = useSettingsStore((s) => s.elevenLabsVoiceId)
+
+  const speakAssistant = useCallback(async () => {
+    const plain = stripMdForSpeech(message.content)
+    if (!plain) return
+    window.speechSynthesis.cancel()
+    setTtsBusy(true)
+    try {
+      if (ttsProvider === 'elevenlabs' && elevenLabsApiKey.trim() && elevenLabsVoiceId.trim()) {
+        await elevenLabsSpeak({
+          apiKey: elevenLabsApiKey.trim(),
+          voiceId: elevenLabsVoiceId.trim(),
+          text: plain.slice(0, 2500),
+        })
+      } else {
+        await new Promise<void>((resolve, reject) => {
+          const u = new SpeechSynthesisUtterance(plain.slice(0, 8000))
+          u.onend = () => resolve()
+          u.onerror = () => reject(new Error('speech'))
+          window.speechSynthesis.speak(u)
+        })
+      }
+    } catch {
+      const u = new SpeechSynthesisUtterance(plain.slice(0, 8000))
+      window.speechSynthesis.speak(u)
+    } finally {
+      setTtsBusy(false)
+    }
+  }, [message.content, ttsProvider, elevenLabsApiKey, elevenLabsVoiceId])
 
   function submitEdit() {
     const trimmed = editDraft.trim()
@@ -71,14 +129,18 @@ export function Message({
     setEditing(false)
   }
 
+  if (isTool) {
+    return (
+      <div className="group flex gap-2 px-6 py-1 text-xs font-mono opacity-90" style={{ color: 'var(--text-secondary)' }}>
+        <span className="shrink-0">🔧 tool</span>
+        <pre className="whitespace-pre-wrap break-words flex-1 m-0">{message.content}</pre>
+        <CopyButton text={message.content} />
+      </div>
+    )
+  }
+
   return (
-    <div
-      className={clsx(
-        'flex gap-3 px-4 py-3 group',
-        isUser ? 'flex-row-reverse' : 'flex-row'
-      )}
-    >
-      {/* Avatar */}
+    <div className={clsx('flex gap-3 px-4 py-3 group', isUser ? 'flex-row-reverse' : 'flex-row')}>
       {showCharAvatar && character ? (
         character.avatarUrl ? (
           <img
@@ -110,8 +172,18 @@ export function Message({
         </div>
       )}
 
-      {/* Bubble */}
       <div className={clsx('flex flex-col gap-1 max-w-[80%]', isUser ? 'items-end' : 'items-start')}>
+        {!isUser && message.reasoning?.trim() && (
+          <details className="text-xs w-full max-w-xl rounded-lg border border-subtle px-2 py-1.5" style={{ background: 'var(--bg-tertiary)' }}>
+            <summary className="cursor-pointer select-none" style={{ color: 'var(--text-secondary)' }}>
+              Thinking
+            </summary>
+            <pre className="mt-1 whitespace-pre-wrap break-words m-0 font-sans" style={{ color: 'var(--text-primary)' }}>
+              {message.reasoning}
+            </pre>
+          </details>
+        )}
+
         <div
           className="rounded-2xl px-4 py-2.5 text-sm leading-relaxed relative"
           style={{
@@ -119,14 +191,14 @@ export function Message({
             borderRadius: isUser ? '1rem 0.25rem 1rem 1rem' : '0.25rem 1rem 1rem 1rem',
           }}
         >
-          {/* Attached image */}
-          {message.imageUrl && (
+          {userImageUrls(message).map((url) => (
             <img
-              src={message.imageUrl}
+              key={url.slice(0, 40)}
+              src={url}
               alt="Attached"
               className="max-w-xs max-h-48 rounded-lg mb-2 object-contain"
             />
-          )}
+          ))}
 
           {editing && isUser ? (
             <div className="flex flex-col gap-2">
@@ -137,7 +209,10 @@ export function Message({
                 style={{ color: 'var(--text-primary)' }}
                 autoFocus
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); submitEdit() }
+                  if (e.key === 'Enter' && !e.shiftKey) {
+                    e.preventDefault()
+                    submitEdit()
+                  }
                   if (e.key === 'Escape') cancelEdit()
                 }}
               />
@@ -151,18 +226,19 @@ export function Message({
               </div>
             </div>
           ) : isUser ? (
-            <p className="whitespace-pre-wrap break-words">{message.content}</p>
+            <div className="text-sm leading-relaxed" style={{ color: 'var(--text-primary)' }}>
+              <MarkdownContent text={message.content} variant="user" />
+            </div>
           ) : (
             <div
               className={clsx(
                 'prose prose-sm max-w-none',
-                message.isStreaming && !message.content && 'streaming-cursor'
+                message.isStreaming && !message.content && 'streaming-cursor',
               )}
               style={{ color: 'var(--text-primary)' }}
             >
               <ReactMarkdown
-                remarkPlugins={[remarkGfm]}
-                disallowedElements={['script']}
+                remarkPlugins={[remarkGfm, remarkBreaks]}
                 components={{
                   code({ className, children, ...props }) {
                     const match = /language-(\w+)/.exec(className || '')
@@ -199,12 +275,7 @@ export function Message({
                   },
                   a({ href, children }) {
                     return (
-                      <a
-                        href={href}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        style={{ color: 'var(--accent)' }}
-                      >
+                      <a href={href} target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent)' }}>
                         {children}
                       </a>
                     )
@@ -220,7 +291,15 @@ export function Message({
                   },
                   th({ children }) {
                     return (
-                      <th style={{ borderBottom: '1px solid var(--border)', padding: '0.4rem 0.75rem', textAlign: 'left', color: 'var(--text-secondary)', fontWeight: 600 }}>
+                      <th
+                        style={{
+                          borderBottom: '1px solid var(--border)',
+                          padding: '0.4rem 0.75rem',
+                          textAlign: 'left',
+                          color: 'var(--text-secondary)',
+                          fontWeight: 600,
+                        }}
+                      >
                         {children}
                       </th>
                     )
@@ -236,22 +315,31 @@ export function Message({
               >
                 {message.content}
               </ReactMarkdown>
-              {message.isStreaming && message.content && (
-                <span className="streaming-cursor" />
-              )}
+              {message.isStreaming && message.content ? <span className="streaming-cursor" /> : null}
             </div>
           )}
         </div>
 
-        {/* Action row */}
         <div className={clsx('flex items-center gap-0.5', isUser ? 'flex-row-reverse' : 'flex-row')}>
           <CopyButton text={message.content} />
+
+          {!isUser && !isStreaming && message.content.trim() && (
+            <button
+              type="button"
+              onClick={() => void speakAssistant()}
+              disabled={ttsBusy}
+              className="p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity btn-ghost disabled:opacity-40"
+              title={ttsProvider === 'elevenlabs' ? 'Read aloud (ElevenLabs or browser fallback)' : 'Read aloud (browser)'}
+            >
+              <Volume2 size={13} />
+            </button>
+          )}
 
           <button
             onClick={() => onBookmark(message.id)}
             className={clsx(
               'p-1 rounded transition-opacity btn-ghost',
-              message.bookmarked ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+              message.bookmarked ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
             )}
             style={message.bookmarked ? { color: 'var(--accent)' } : undefined}
             title={message.bookmarked ? 'Remove bookmark' : 'Bookmark'}
@@ -261,7 +349,10 @@ export function Message({
 
           {isUser && !isStreaming && (
             <button
-              onClick={() => { setEditDraft(message.content); setEditing(true) }}
+              onClick={() => {
+                setEditDraft(message.content)
+                setEditing(true)
+              }}
               className="p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity btn-ghost"
               title="Edit message"
             >
@@ -288,7 +379,10 @@ export function Message({
           </button>
 
           {message.tokenCount != null && (
-            <span className="text-xs opacity-0 group-hover:opacity-100 transition-opacity" style={{ color: 'var(--text-secondary)' }}>
+            <span
+              className="text-xs opacity-0 group-hover:opacity-100 transition-opacity"
+              style={{ color: 'var(--text-secondary)' }}
+            >
               {estimateCost(message.tokenCount)}
             </span>
           )}

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -5,6 +5,7 @@ interface AppLayoutProps {
   children: React.ReactNode
   onOpenSettings: () => void
   onOpenBookmarks: () => void
+  onOpenUsage: () => void
   view: 'chat' | 'characters'
   onChangeView: (v: 'chat' | 'characters') => void
   sidebarOpen: boolean
@@ -15,6 +16,7 @@ export function AppLayout({
   children,
   onOpenSettings,
   onOpenBookmarks,
+  onOpenUsage,
   view,
   onChangeView,
   sidebarOpen,
@@ -48,6 +50,7 @@ export function AppLayout({
         onToggle={() => setSidebarCollapsed((v) => !v)}
         onOpenSettings={() => { onOpenSettings(); closeMobile() }}
         onOpenBookmarks={() => { onOpenBookmarks(); closeMobile() }}
+        onOpenUsage={() => { onOpenUsage(); closeMobile() }}
         view={view}
         onChangeView={handleChangeView}
         mobileOpen={sidebarOpen}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect } from 'react'
 import {
   MessageSquare, Plus, Trash2, Settings, ChevronLeft, ChevronRight,
   Download, Upload, Pin, PinOff, Search, Bookmark, ChevronDown, Users, X, Archive,
-  Pencil, FolderPlus, Folder,
+  Pencil, FolderPlus, Folder, BarChart3,
 } from 'lucide-react'
 import { useChatStore } from '../../store/chatStore'
 import { useSettingsStore } from '../../store/settingsStore'
@@ -14,6 +14,7 @@ interface SidebarProps {
   onToggle: () => void
   onOpenSettings: () => void
   onOpenBookmarks: () => void
+  onOpenUsage: () => void
   view: 'chat' | 'characters'
   onChangeView: (v: 'chat' | 'characters') => void
   /** Whether the mobile overlay is open. Ignored on >= md screens. */
@@ -23,7 +24,7 @@ interface SidebarProps {
 }
 
 export function Sidebar({
-  collapsed, onToggle, onOpenSettings, onOpenBookmarks, view, onChangeView,
+  collapsed, onToggle, onOpenSettings, onOpenBookmarks, onOpenUsage, view, onChangeView,
   mobileOpen = false, onMobileClose,
 }: SidebarProps) {
   const chats = useChatStore((s) => s.chats)
@@ -398,6 +399,15 @@ export function Sidebar({
         >
           <Bookmark size={15} />
           {!effectiveCollapsed && <span>Bookmarks</span>}
+        </button>
+
+        <button
+          onClick={onOpenUsage}
+          className={clsx('btn-ghost flex items-center gap-2 w-full text-sm', effectiveCollapsed ? 'justify-center' : '')}
+          title="Usage estimates (Ctrl+U)"
+        >
+          <BarChart3 size={15} />
+          {!effectiveCollapsed && <span>Usage</span>}
         </button>
 
         {/* ─── Backup: prominent top-level buttons ─── */}

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -112,6 +112,10 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
   const customThemeVars = useSettingsStore((s) => s.customThemeVars)
   const freeProvider = useSettingsStore((s) => s.freeProvider)
   const predictiveText = useSettingsStore((s) => s.predictiveText)
+  const useAiChatTitles = useSettingsStore((s) => s.useAiChatTitles)
+  const ttsProvider = useSettingsStore((s) => s.ttsProvider)
+  const elevenLabsApiKey = useSettingsStore((s) => s.elevenLabsApiKey)
+  const elevenLabsVoiceId = useSettingsStore((s) => s.elevenLabsVoiceId)
   const setApiKey = useSettingsStore((s) => s.setApiKey)
   const setBuilderApiKey = useSettingsStore((s) => s.setBuilderApiKey)
   const setTheme = useSettingsStore((s) => s.setTheme)
@@ -119,6 +123,10 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
   const setCustomThemeVars = useSettingsStore((s) => s.setCustomThemeVars)
   const setFreeProvider = useSettingsStore((s) => s.setFreeProvider)
   const setPredictiveText = useSettingsStore((s) => s.setPredictiveText)
+  const setUseAiChatTitles = useSettingsStore((s) => s.setUseAiChatTitles)
+  const setTtsProvider = useSettingsStore((s) => s.setTtsProvider)
+  const setElevenLabsApiKey = useSettingsStore((s) => s.setElevenLabsApiKey)
+  const setElevenLabsVoiceId = useSettingsStore((s) => s.setElevenLabsVoiceId)
 
   return (
     <div
@@ -186,6 +194,83 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
               Shows AI-powered text suggestions as you type. Press <strong>Tab</strong> to accept.
               {!apiKey && !freeProvider.enabled && ' Requires an API key or free provider to be configured.'}
             </p>
+          </section>
+
+          <section>
+            <h3 className="font-semibold text-sm mb-3">Chat titles</h3>
+            <label className="flex items-center gap-3 cursor-pointer">
+              <div
+                onClick={() => setUseAiChatTitles(!useAiChatTitles)}
+                className="w-10 h-5 rounded-full relative transition-colors cursor-pointer"
+                style={{
+                  background: useAiChatTitles ? 'var(--accent)' : 'var(--bg-tertiary)',
+                  border: '1px solid var(--border)',
+                }}
+              >
+                <div
+                  className="absolute top-0.5 w-3.5 h-3.5 rounded-full transition-transform"
+                  style={{
+                    background: useAiChatTitles ? 'white' : 'var(--text-secondary)',
+                    transform: useAiChatTitles ? 'translateX(22px)' : 'translateX(3px)',
+                  }}
+                />
+              </div>
+              <span className="text-sm">{useAiChatTitles ? 'AI titles' : 'First line as title'}</span>
+            </label>
+            <p className="text-xs text-muted mt-2">
+              When on, new chats stay named &quot;New Chat&quot; until the first reply, then a small model suggests a
+              short title. When off, the first user message still seeds the title (legacy behavior).
+            </p>
+          </section>
+
+          <section>
+            <h3 className="font-semibold text-sm mb-3">Read aloud (assistant)</h3>
+            <div className="flex flex-col gap-2 text-sm">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="tts"
+                  checked={ttsProvider === 'browser'}
+                  onChange={() => setTtsProvider('browser')}
+                />
+                Browser voices (free, offline-capable)
+              </label>
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="tts"
+                  checked={ttsProvider === 'elevenlabs'}
+                  onChange={() => setTtsProvider('elevenlabs')}
+                />
+                ElevenLabs (API key; may be blocked by CORS in some browsers — falls back to browser)
+              </label>
+            </div>
+            {ttsProvider === 'elevenlabs' && (
+              <div className="mt-3 space-y-2">
+                <div>
+                  <label className="text-xs text-muted block mb-1">ElevenLabs API key</label>
+                  <input
+                    type="password"
+                    value={elevenLabsApiKey}
+                    onChange={(e) => setElevenLabsApiKey(e.target.value)}
+                    placeholder="xi-api-key…"
+                    className="w-full px-3 py-2 rounded-lg border border-subtle text-sm font-mono bg-transparent outline-none"
+                    style={{ background: 'var(--bg-tertiary)', color: 'var(--text-primary)' }}
+                  />
+                </div>
+                <div>
+                  <label className="text-xs text-muted block mb-1">Voice ID</label>
+                  <input
+                    type="text"
+                    value={elevenLabsVoiceId}
+                    onChange={(e) => setElevenLabsVoiceId(e.target.value)}
+                    placeholder="21m00Tcm4TlvDq8ikWAM"
+                    className="w-full px-3 py-2 rounded-lg border border-subtle text-sm font-mono bg-transparent outline-none"
+                    style={{ background: 'var(--bg-tertiary)', color: 'var(--text-primary)' }}
+                  />
+                </div>
+              </div>
+            )}
           </section>
 
           {/* Conversation Memory */}

--- a/src/components/usage/UsagePanel.tsx
+++ b/src/components/usage/UsagePanel.tsx
@@ -1,0 +1,106 @@
+import { useMemo } from 'react'
+import { X } from 'lucide-react'
+import { useChatStore } from '../../store/chatStore'
+import { useModelStore } from '../../store/modelStore'
+
+function parsePricePerMillionUsd(s: string): number {
+  const n = parseFloat(s)
+  return Number.isFinite(n) ? n : 0
+}
+
+export function UsagePanel({ onClose }: { onClose: () => void }) {
+  const chats = useChatStore((s) => s.chats)
+  const models = useModelStore((s) => s.models)
+
+  const modelMap = useMemo(() => new Map(models.map((m) => [m.id, m])), [models])
+
+  const rows = useMemo(() => {
+    type Row = { modelId: string; completionTok: number; usd: number }
+    const byModel = new Map<string, Row>()
+
+    for (const c of chats) {
+      for (const m of c.messages) {
+        if (m.role !== 'assistant' || m.tokenCount == null) continue
+        const modelId = c.modelId
+        const r = byModel.get(modelId) ?? { modelId, completionTok: 0, usd: 0 }
+        r.completionTok += m.tokenCount
+        const pricing = modelMap.get(modelId)?.pricing
+        if (pricing) {
+          r.usd += (m.tokenCount / 1_000_000) * parsePricePerMillionUsd(pricing.completion)
+        }
+        byModel.set(modelId, r)
+      }
+    }
+    return [...byModel.values()].sort((a, b) => b.completionTok - a.completionTok)
+  }, [chats, modelMap])
+
+  const totals = useMemo(() => {
+    let tok = 0
+    let usd = 0
+    for (const r of rows) {
+      tok += r.completionTok
+      usd += r.usd
+    }
+    return { tok, usd }
+  }, [rows])
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ background: 'rgba(0,0,0,0.65)' }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div
+        className="w-full max-w-lg rounded-2xl shadow-2xl overflow-hidden max-h-[85vh] flex flex-col"
+        style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border)' }}
+      >
+        <div className="flex items-center justify-between px-5 py-4 border-b border-subtle shrink-0">
+          <h2 className="font-bold text-base">Usage (estimate)</h2>
+          <button type="button" onClick={onClose} className="btn-ghost p-1.5 rounded-lg" title="Close">
+            <X size={16} />
+          </button>
+        </div>
+        <div className="p-5 overflow-y-auto text-sm flex flex-col gap-4">
+          <p className="text-xs text-muted">
+            Counts reflect <strong>assistant</strong> messages only (streamed output tokens). Cost uses each
+            model&apos;s completion price from the last model list fetch. OpenRouter bills prompt + completion on
+            their side; this panel is a rough local hint.
+          </p>
+          <div className="rounded-lg border border-subtle p-3" style={{ background: 'var(--bg-tertiary)' }}>
+            <div className="text-xs text-muted">Assistant output (stored)</div>
+            <div className="text-lg font-semibold mt-1">{totals.tok.toLocaleString()} tokens</div>
+            <div className="text-sm mt-0.5" style={{ color: 'var(--text-secondary)' }}>
+              ~${totals.usd.toFixed(4)} USD <span className="text-xs">(completion rate only)</span>
+            </div>
+          </div>
+          {rows.length === 0 ? (
+            <p className="text-muted text-sm">No assistant token counts yet. Chat a bit, then reopen.</p>
+          ) : (
+            <table className="w-full text-xs border-collapse">
+              <thead>
+                <tr style={{ color: 'var(--text-secondary)', textAlign: 'left' }}>
+                  <th className="py-1 pr-2">Model</th>
+                  <th className="py-1 pr-2">Out tokens</th>
+                  <th className="py-1">~USD</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((r) => (
+                  <tr key={r.modelId} style={{ borderTop: '1px solid var(--border)' }}>
+                    <td className="py-1.5 pr-2 font-mono truncate max-w-[200px]" title={r.modelId}>
+                      {r.modelId}
+                    </td>
+                    <td className="py-1.5 pr-2">{r.completionTok.toLocaleString()}</td>
+                    <td className="py-1.5">${r.usd.toFixed(4)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/useStreamingChat.ts
+++ b/src/hooks/useStreamingChat.ts
@@ -5,18 +5,52 @@ import { useChatStore } from '../store/chatStore'
 import { useSettingsStore } from '../store/settingsStore'
 import { useMemoryStore } from '../store/memoryStore'
 import type { Message } from '../types'
+import { generateChatTitle } from '../api/chatTitle'
+import {
+  BUILTIN_OPENROUTER_TOOLS,
+  isBuiltinToolName,
+  runBuiltinTool,
+} from '../api/builtinTools'
+
+const MAX_TOOL_DEPTH = 6
+
+function parseExtraTools(json?: string): unknown[] {
+  if (!json?.trim()) return []
+  try {
+    const v = JSON.parse(json) as unknown
+    return Array.isArray(v) ? v : []
+  } catch {
+    return []
+  }
+}
+
+function parseResponseFormat(jsonSchemaText?: string): unknown | undefined {
+  if (!jsonSchemaText?.trim()) return undefined
+  try {
+    const schemaObj = JSON.parse(jsonSchemaText) as Record<string, unknown>
+    return {
+      type: 'json_schema',
+      json_schema: { name: 'response', strict: true, schema: schemaObj },
+    }
+  } catch {
+    return undefined
+  }
+}
 
 export function useStreamingChat() {
   const [isStreaming, setIsStreaming] = useState(false)
   const cancelRef = useRef<(() => void) | null>(null)
+  const titlingRef = useRef(new Set<string>())
   const addMessage = useChatStore((s) => s.addMessage)
   const updateMessage = useChatStore((s) => s.updateMessage)
+  const patchMessage = useChatStore((s) => s.patchMessage)
   const finalizeMessage = useChatStore((s) => s.finalizeMessage)
   const truncateMessagesAfter = useChatStore((s) => s.truncateMessagesAfter)
-  const chats = useChatStore((s) => s.chats)
+  const renameChat = useChatStore((s) => s.renameChat)
   const apiKey = useSettingsStore((s) => s.apiKey)
   const freeProvider = useSettingsStore((s) => s.freeProvider)
   const pushRecentModel = useSettingsStore((s) => s.pushRecentModel)
+  const useAiChatTitles = useSettingsStore((s) => s.useAiChatTitles)
 
   const getActiveMemoryPrompt = useMemoryStore((s) => s.getActiveMemoryPrompt)
 
@@ -28,13 +62,43 @@ export function useStreamingChat() {
     setIsStreaming(false)
   }
 
+  function maybeRenameWithAiTitle(chatId: string) {
+    if (!useAiChatTitles || !apiKey) return
+    if (titlingRef.current.has(chatId)) return
+    const chat = useChatStore.getState().chats.find((c) => c.id === chatId)
+    if (!chat || chat.title !== 'New Chat') return
+    const users = chat.messages.filter((m) => m.role === 'user')
+    const assts = chat.messages.filter((m) => m.role === 'assistant' && !m.isStreaming)
+    if (users.length < 1 || assts.length < 1) return
+    const lastAsst = assts[assts.length - 1]
+    if (!lastAsst.content.trim() && !lastAsst.assistantToolCalls) return
+
+    titlingRef.current.add(chatId)
+    void (async () => {
+      try {
+        const u0 = users[0]?.content ?? ''
+        const a0 = lastAsst.content ?? ''
+        const t = await generateChatTitle(apiKey, u0, a0)
+        if (t) renameChat(chatId, t)
+      } catch {
+        /* ignore title failures */
+      } finally {
+        titlingRef.current.delete(chatId)
+      }
+    })()
+  }
+
   function _stream(
     chatId: string,
-    historyMessages: Pick<Message, 'role' | 'content' | 'imageUrl'>[],
+    historyMessages: Message[],
     modelId: string,
-    systemPrompt: string | undefined
+    systemPrompt: string | undefined,
+    depth: number,
   ) {
-    const assistantMsg: Message = addMessage(chatId, {
+    const chat = useChatStore.getState().chats.find((c) => c.id === chatId)
+    if (!chat) return
+
+    const assistantMsg = addMessage(chatId, {
       role: 'assistant',
       content: '',
       isStreaming: true,
@@ -44,15 +108,72 @@ export function useStreamingChat() {
 
     let accumulated = ''
 
+    const temperature = chat.temperature
+    const maxTokens = chat.maxTokens
+
+    const extraTools = parseExtraTools(chat.toolsJson)
+    const tools =
+      chat.experimentalTools && (BUILTIN_OPENROUTER_TOOLS.length || extraTools.length)
+        ? [...BUILTIN_OPENROUTER_TOOLS, ...extraTools]
+        : undefined
+    const responseFormat = parseResponseFormat(chat.jsonSchemaText)
+
     const callbacks = {
       onDelta: (delta: string) => {
         accumulated += delta
         updateMessage(chatId, assistantMsg.id, accumulated)
       },
-      onDone: (tokenCount?: number) => {
+      onReasoningDelta: (chunk: string) => {
+        const st = useChatStore.getState()
+        const m = st.chats
+          .find((c) => c.id === chatId)
+          ?.messages.find((x) => x.id === assistantMsg.id)
+        const prev = m?.reasoning ?? ''
+        patchMessage(chatId, assistantMsg.id, { reasoning: prev + chunk })
+      },
+      onDone: (
+        tokenCount?: number,
+        meta?: { finishReason?: string | null; toolCalls?: Array<{ id: string; type: 'function'; function: { name: string; arguments: string } }> | null },
+      ) => {
+        const finishReason = meta?.finishReason
+        const streamedToolCalls = meta?.toolCalls ?? null
+
+        const shouldTool =
+          depth < MAX_TOOL_DEPTH &&
+          streamedToolCalls &&
+          streamedToolCalls.length > 0 &&
+          (finishReason === 'tool_calls' || (!accumulated.trim() && finishReason !== 'length'))
+
+        if (shouldTool) {
+          patchMessage(chatId, assistantMsg.id, {
+            assistantToolCalls: JSON.stringify(streamedToolCalls),
+            content: accumulated,
+            isStreaming: false,
+            ...(tokenCount !== undefined ? { tokenCount } : {}),
+          })
+
+          for (const call of streamedToolCalls) {
+            const out = isBuiltinToolName(call.function.name)
+              ? runBuiltinTool(call.function.name, call.function.arguments)
+              : JSON.stringify({ error: `unsupported_tool:${call.function.name}` })
+            addMessage(chatId, {
+              role: 'tool',
+              content: out,
+              toolCallId: call.id,
+            })
+          }
+
+          const nextHistory = useChatStore.getState().chats.find((c) => c.id === chatId)?.messages ?? []
+          const memoryPrompt = getActiveMemoryPrompt()
+          const fullSystemPrompt = [memoryPrompt, chat.systemPrompt].filter(Boolean).join('\n\n') || undefined
+          _stream(chatId, nextHistory, modelId, fullSystemPrompt, depth + 1)
+          return
+        }
+
         finalizeMessage(chatId, assistantMsg.id, tokenCount)
         setIsStreaming(false)
         cancelRef.current = null
+        maybeRenameWithAiTitle(chatId)
       },
       onError: (err: Error) => {
         updateMessage(chatId, assistantMsg.id, `⚠️ Error: ${err.message}`)
@@ -65,14 +186,19 @@ export function useStreamingChat() {
     let cancel: () => void
 
     if (useFree) {
-      const provider = freeProvider.type === 'pollinations'
-        ? getPollinationsProvider(freeProvider.pollinationsKey, freeProvider.pollinationsModel)
-        : getCustomProvider(freeProvider.customUrl, freeProvider.customKey, freeProvider.customModel)
+      const provider =
+        freeProvider.type === 'pollinations'
+          ? getPollinationsProvider(freeProvider.pollinationsKey, freeProvider.pollinationsModel)
+          : getCustomProvider(freeProvider.customUrl, freeProvider.customKey, freeProvider.customModel)
 
       cancel = streamFree({
         provider,
         messages: historyMessages,
         systemPrompt,
+        temperature,
+        maxTokens,
+        tools,
+        responseFormat,
         ...callbacks,
       })
     } else {
@@ -81,6 +207,10 @@ export function useStreamingChat() {
         modelId,
         messages: historyMessages,
         systemPrompt,
+        temperature,
+        maxTokens,
+        tools,
+        responseFormat,
         ...callbacks,
       })
     }
@@ -88,30 +218,49 @@ export function useStreamingChat() {
     cancelRef.current = cancel
   }
 
-  function sendMessage(chatId: string, userContent: string, imageUrl?: string) {
-    const chat = chats.find((c) => c.id === chatId)
+  function sendMessage(
+    chatId: string,
+    userContent: string,
+    opts?: { imageUrls?: string[]; imageUrl?: string; fileExtracts?: { name: string; text: string }[] },
+  ) {
+    const chat = useChatStore.getState().chats.find((c) => c.id === chatId)
     if (!chat) return
 
     pushRecentModel(chat.modelId)
     cancelRef.current?.()
 
-    addMessage(chatId, { role: 'user', content: userContent, imageUrl })
+    const urls = [...(opts?.imageUrls ?? [])]
+    if (opts?.imageUrl) urls.unshift(opts.imageUrl)
+    const dedup = [...new Set(urls)]
 
-    const historyMessages: Pick<Message, 'role' | 'content' | 'imageUrl'>[] = [
-      ...chat.messages.map(({ role, content, imageUrl }) => ({ role, content, imageUrl })),
-      { role: 'user' as const, content: userContent, imageUrl },
-    ]
+    let text = userContent
+    if (opts?.fileExtracts?.length) {
+      const blocks = opts.fileExtracts
+        .map((f) => `### Attached file: ${f.name}\n\n${f.text}`)
+        .join('\n\n')
+      text = text.trim() ? `${text.trim()}\n\n${blocks}` : blocks
+    }
 
+    addMessage(chatId, {
+      role: 'user',
+      content: text,
+      ...(dedup.length === 1
+        ? { imageUrl: dedup[0], imageUrls: dedup }
+        : dedup.length > 1
+          ? { imageUrls: dedup }
+          : {}),
+    })
+
+    const historyMessages = useChatStore.getState().chats.find((c) => c.id === chatId)?.messages ?? []
     const memoryPrompt = getActiveMemoryPrompt()
     const fullSystemPrompt = [memoryPrompt, chat.systemPrompt].filter(Boolean).join('\n\n') || undefined
-    _stream(chatId, historyMessages, chat.modelId, fullSystemPrompt)
+    _stream(chatId, historyMessages, chat.modelId, fullSystemPrompt, 0)
   }
 
   function regenerate(chatId: string) {
-    const chat = chats.find((c) => c.id === chatId)
+    const chat = useChatStore.getState().chats.find((c) => c.id === chatId)
     if (!chat) return
 
-    // Find the last assistant message and remove it
     const messages = [...chat.messages]
     let lastAssistantIdx = -1
     for (let i = messages.length - 1; i >= 0; i--) {
@@ -125,47 +274,39 @@ export function useStreamingChat() {
     const lastAssistantId = messages[lastAssistantIdx].id
     truncateMessagesAfter(chatId, lastAssistantId)
 
-    // Build history up to (but not including) the removed assistant message
-    const historyMessages = messages
-      .slice(0, lastAssistantIdx)
-      .map(({ role, content, imageUrl }) => ({ role, content, imageUrl }))
+    const historyMessages =
+      useChatStore.getState().chats.find((c) => c.id === chatId)?.messages ?? []
 
     cancelRef.current?.()
     pushRecentModel(chat.modelId)
     const memoryPrompt2 = getActiveMemoryPrompt()
     const fullSys2 = [memoryPrompt2, chat.systemPrompt].filter(Boolean).join('\n\n') || undefined
-    _stream(chatId, historyMessages, chat.modelId, fullSys2)
+    _stream(chatId, historyMessages, chat.modelId, fullSys2, 0)
   }
 
   function editAndResend(chatId: string, messageId: string, newContent: string) {
-    const chat = chats.find((c) => c.id === chatId)
+    const chat = useChatStore.getState().chats.find((c) => c.id === chatId)
     if (!chat) return
 
     const idx = chat.messages.findIndex((m) => m.id === messageId)
     if (idx === -1) return
 
-    // Truncate everything after this message (removes old response)
     const nextMsg = chat.messages[idx + 1]
     if (nextMsg) {
       truncateMessagesAfter(chatId, nextMsg.id)
     }
 
-    // Update the user message content
     updateMessage(chatId, messageId, newContent)
 
-    // Build history up to and including this edited message
-    const historyMessages = [
-      ...chat.messages
-        .slice(0, idx)
-        .map(({ role, content, imageUrl }) => ({ role, content, imageUrl })),
-      { role: 'user' as const, content: newContent, imageUrl: chat.messages[idx].imageUrl },
-    ]
+    const fresh = useChatStore.getState().chats.find((c) => c.id === chatId)
+    if (!fresh) return
+    const historyMessages = fresh.messages.slice(0, idx + 1)
 
     cancelRef.current?.()
     pushRecentModel(chat.modelId)
     const memoryPrompt3 = getActiveMemoryPrompt()
     const fullSys3 = [memoryPrompt3, chat.systemPrompt].filter(Boolean).join('\n\n') || undefined
-    _stream(chatId, historyMessages, chat.modelId, fullSys3)
+    _stream(chatId, historyMessages, chat.modelId, fullSys3, 0)
   }
 
   return { sendMessage, regenerate, editAndResend, isStreaming, cancelStream, useFreeProvider: useFree }

--- a/src/index.css
+++ b/src/index.css
@@ -244,3 +244,8 @@ body.is-idle {
 
 /* Code block overrides for dark syntax themes */
 pre { border-radius: 0.5rem; overflow: hidden; }
+
+textarea.composer-md-input::selection {
+  background: color-mix(in srgb, var(--accent) 42%, transparent);
+  color: var(--text-primary);
+}

--- a/src/store/chatStore.ts
+++ b/src/store/chatStore.ts
@@ -25,6 +25,7 @@ interface ChatState {
   setActiveChatId: (id: string | null) => void
   addMessage: (chatId: string, message: Omit<Message, 'id' | 'createdAt'>) => Message
   updateMessage: (chatId: string, messageId: string, content: string) => void
+  patchMessage: (chatId: string, messageId: string, updates: Partial<Message>) => void
   finalizeMessage: (chatId: string, messageId: string, tokenCount?: number) => void
   deleteMessage: (chatId: string, messageId: string) => void
   toggleBookmarkMessage: (chatId: string, messageId: string) => void
@@ -119,9 +120,12 @@ export const useChatStore = create<ChatState>()(
           chats: s.chats.map((c) => {
             if (c.id !== chatId) return c
             const messages = [...c.messages, message]
+            const useAiTitles = useSettingsStore.getState().useAiChatTitles
             const title =
               c.title === 'New Chat' && msg.role === 'user'
-                ? msg.content.slice(0, 52).trim()
+                ? useAiTitles
+                  ? c.title
+                  : msg.content.slice(0, 52).trim()
                 : c.title
             return { ...c, messages, title, updatedAt: Date.now() }
           }),
@@ -137,6 +141,21 @@ export const useChatStore = create<ChatState>()(
               ...c,
               messages: c.messages.map((m) =>
                 m.id === messageId ? { ...m, content } : m
+              ),
+              updatedAt: Date.now(),
+            }
+          }),
+        }))
+      },
+
+      patchMessage: (chatId, messageId, updates) => {
+        set((s) => ({
+          chats: s.chats.map((c) => {
+            if (c.id !== chatId) return c
+            return {
+              ...c,
+              messages: c.messages.map((m) =>
+                m.id === messageId ? { ...m, ...updates } : m
               ),
               updatedAt: Date.now(),
             }
@@ -431,6 +450,20 @@ export const useChatStore = create<ChatState>()(
     }),
     {
       name: 'openstarchat-chats',
+      version: 1,
+      migrate: (persisted, version) => {
+        const p = persisted as { chats?: Chat[] } | undefined
+        if (version < 1 && p?.chats) {
+          for (const c of p.chats) {
+            for (const m of c.messages ?? []) {
+              if (m.imageUrl && !m.imageUrls?.length) {
+                m.imageUrls = [m.imageUrl]
+              }
+            }
+          }
+        }
+        return persisted as never
+      },
       partialize: (state) => ({
         chats: state.chats.map((c) => ({
           ...c,

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -64,6 +64,11 @@ interface SettingsState {
   customThemeVars: CustomThemeVars
   freeProvider: FreeProviderConfig
   predictiveText: boolean
+  /** When true, chat titles stay “New Chat” until the first assistant reply, then a small model names the thread. */
+  useAiChatTitles: boolean
+  ttsProvider: 'browser' | 'elevenlabs'
+  elevenLabsApiKey: string
+  elevenLabsVoiceId: string
   setApiKey: (key: string) => void
   setBuilderApiKey: (key: string) => void
   setTheme: (theme: ThemeName) => void
@@ -75,6 +80,10 @@ interface SettingsState {
   setCustomThemeVars: (vars: Partial<CustomThemeVars>) => void
   setFreeProvider: (updates: Partial<FreeProviderConfig>) => void
   setPredictiveText: (v: boolean) => void
+  setUseAiChatTitles: (v: boolean) => void
+  setTtsProvider: (v: 'browser' | 'elevenlabs') => void
+  setElevenLabsApiKey: (key: string) => void
+  setElevenLabsVoiceId: (id: string) => void
 }
 
 export const useSettingsStore = create<SettingsState>()(
@@ -90,6 +99,10 @@ export const useSettingsStore = create<SettingsState>()(
       customThemeVars: DEFAULT_CUSTOM_THEME,
       freeProvider: DEFAULT_FREE_PROVIDER,
       predictiveText: false,
+      useAiChatTitles: true,
+      ttsProvider: 'browser',
+      elevenLabsApiKey: '',
+      elevenLabsVoiceId: '',
 
       setApiKey: (key) => set({ apiKey: key }),
       setBuilderApiKey: (key) => set({ builderApiKey: key }),
@@ -134,6 +147,10 @@ export const useSettingsStore = create<SettingsState>()(
         set((s) => ({ freeProvider: { ...s.freeProvider, ...updates } })),
 
       setPredictiveText: (v) => set({ predictiveText: v }),
+      setUseAiChatTitles: (v) => set({ useAiChatTitles: v }),
+      setTtsProvider: (v) => set({ ttsProvider: v }),
+      setElevenLabsApiKey: (key) => set({ elevenLabsApiKey: key }),
+      setElevenLabsVoiceId: (id) => set({ elevenLabsVoiceId: id }),
     }),
     {
       name: 'openstarchat-settings',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,15 +16,26 @@ export interface Model {
   }
 }
 
+export type MessageRole = 'user' | 'assistant' | 'system' | 'tool'
+
 export interface Message {
   id: string
-  role: 'user' | 'assistant' | 'system'
+  role: MessageRole
   content: string
+  /** @deprecated Prefer imageUrls; kept for persisted chats */
   imageUrl?: string
+  /** Data URLs or https URLs — multimodal user turns */
+  imageUrls?: string[]
   createdAt: number
   isStreaming?: boolean
   bookmarked?: boolean
   tokenCount?: number
+  /** Model reasoning trace (streamed), when the provider exposes it */
+  reasoning?: string
+  /** OpenAI-style tool_calls JSON on an assistant message */
+  assistantToolCalls?: string
+  /** For role === 'tool' — links the tool output to the assistant tool_calls id */
+  toolCallId?: string
 }
 
 export interface Chat {
@@ -41,6 +52,12 @@ export interface Chat {
   tags?: string[]
   temperature?: number
   maxTokens?: number
+  /** When true, register built-in tools (time, random int) the model may call */
+  experimentalTools?: boolean
+  /** Optional extra OpenAI-format tool definitions (JSON array). Merged with built-ins when experimentalTools is on. */
+  toolsJson?: string
+  /** When set, request JSON that matches this JSON Schema object (OpenRouter structured outputs). */
+  jsonSchemaText?: string
 }
 
 export interface ChatFolder {

--- a/src/utils/extractPdfText.ts
+++ b/src/utils/extractPdfText.ts
@@ -1,0 +1,21 @@
+/** Extract plain text from a PDF file in the browser (best-effort). */
+export async function extractPdfTextAsString(file: File): Promise<string> {
+  const buf = await file.arrayBuffer()
+  const pdfjs = await import('pdfjs-dist')
+  pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+    'pdfjs-dist/build/pdf.worker.min.mjs',
+    import.meta.url,
+  ).toString()
+
+  const doc = await pdfjs.getDocument({ data: buf }).promise
+  const parts: string[] = []
+  for (let i = 1; i <= doc.numPages; i++) {
+    const page = await doc.getPage(i)
+    const textContent = await page.getTextContent()
+    const line = textContent.items
+      .map((it) => ('str' in it ? (it as { str: string }).str : ''))
+      .join(' ')
+    parts.push(line.trim())
+  }
+  return parts.filter(Boolean).join('\n\n').trim()
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This updates the README to reflect the current product, adds richer chat input and message rendering, and implements several advanced OpenRouter features end-to-end in the SPA.

## Changes

- **README**: full feature list, shortcuts, stack, and run instructions.
- **Markdown**: user messages render as Markdown; the composer uses a scroll-synced Markdown underlay with visible caret and selection styling.
- **Streaming API**: `temperature`, `max_tokens`, optional `response_format` (JSON Schema text), optional `tools`, reasoning deltas when present, and `tool_calls` handling with a bounded follow-up round-trip.
- **Built-in tools**: `get_current_datetime` and `get_random_int` (safe local execution); extra tool definitions can be merged from JSON; unknown tool names return an error payload to the model.
- **Attachments**: multiple images per turn; PDF text extraction via lazy-loaded `pdfjs-dist`; plain text files appended as markdown sections.
- **Titles**: optional AI-generated chat title (Settings) after the first substantive assistant reply.
- **TTS**: per-message read-aloud using browser speech or optional ElevenLabs (with browser fallback).
- **Usage**: modal (sidebar + Ctrl/Cmd+U) estimating assistant output tokens and approximate USD from cached model pricing.
- **Persistence**: migrate stored messages to set `imageUrls` from legacy `imageUrl` when upgrading the chats store version.

## Notes

- ElevenLabs from the browser may hit CORS restrictions depending on environment; the code falls back to `speechSynthesis` on failure.
- The usage panel is an estimate (assistant token counts + completion pricing); actual billing is on OpenRouter.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1db7e7d-5d66-4093-be0b-0eb4158e9c76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1db7e7d-5d66-4093-be0b-0eb4158e9c76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

